### PR TITLE
sortMergeRollupAndCount

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1067,9 +1067,10 @@ lazy val `scio-extra` = project
   .enablePlugins(SbtAvro)
   .dependsOn(
     `scio-core` % "compile;provided->provided;test->test",
-    `scio-avro`,
+    `scio-avro` % "compile;test->test",
     `scio-google-cloud-platform`,
-    `scio-macros`
+    `scio-macros`,
+    `scio-smb` % "provided;test->test"
   )
   .settings(commonSettings)
   .settings(macroSettings)

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
@@ -96,18 +96,11 @@ trait SCollectionSyntax extends SortMergeBucketScioContextSyntax {
       extends Serializable {
 
     /**
-     * SMB-optimized variant of [[RollupOps.rollupAndCount]] that eliminates the expensive
-     * correction branch shuffle by leveraging sort-merge bucket co-location.
+     * SMB-aware variant of [[RollupOps.rollupAndCount]] that reads from sort-merge buckets.
      *
-     * In the general [[RollupOps.rollupAndCount]], the correction branch requires a `groupByKey` on
-     * `(uniqueKey, D)` to detect double-counted users across rollup dimensions — this shuffle is
-     * typically the dominant cost. When the input is SMB-keyed by the unique key,
-     * `sortMergeGroupByKey` already delivers all records per key to the same worker, so corrections
-     * can be computed locally without a shuffle.
-     *
-     * Branch 1 (main) is unchanged: drop unique key, aggregate to metric level via `sumByKey`,
-     * then expand rollup dimensions on the small aggregated data. Branch 2 (correction) replaces
-     * the `groupByKey` with a local per-key computation inside the SMB read.
+     * Reads SMB-keyed data via `sortMergeGroupByKey`, consumes the (potentially lazy) per-key
+     * iterable once via `perKeyFn`, and extracts `(U, D, R, M)` tuples that are then processed
+     * by the standard [[RollupOps.rollupAndCount]].
      *
      * @param keyClass
      *   SMB key class (= unique key to count distinct, typically userId)
@@ -129,63 +122,12 @@ trait SCollectionSyntax extends SortMergeBucketScioContextSyntax {
       targetParallelism: TargetParallelism = TargetParallelism.auto()
     )(implicit g: Group[M]): SCollection[((D, R), (M, Long))] = {
 
-      // Single flatMap consumes the lazy SMB iterable once via perKeyFn (which returns Seq).
-      // Emits tagged records: true = main (un-expanded), false = correction (already expanded).
-      val tagged = self
+      self
         .sortMergeGroupByKey(keyClass, read, targetParallelism)
-        .withName("SortMergeRollupAndCount")
         .flatMap { case (key, values) =>
-          val tuples = perKeyFn(key, values)
-
-          val main = tuples.iterator.map { case (d, r, m) =>
-            (true, ((d, r), (m, 1L)))
-          }
-
-          val corrections = tuples
-            .groupBy(_._1)
-            .iterator
-            .flatMap { case (d, byD) =>
-              if (byD.size <= 1) Iterator.empty
-              else {
-                val rollupMap = collection.mutable.Map.empty[R, Long]
-                for ((_, r, _) <- byD; r2 <- rollupFunction(r)) {
-                  rollupMap(r2) = rollupMap.getOrElse(r2, 1L) - 1L
-                }
-                rollupMap.iterator.collect {
-                  case (r2, count) if count < 0L =>
-                    (false, ((d, r2), (g.zero, count)))
-                }
-              }
-            }
-
-          main ++ corrections
+          perKeyFn(key, values).map { case (d, r, m) => (key, d, r, m) }
         }
-
-      // Branch 1 (main): sum metric first (massive reduction), then expand rollups.
-      val main = tagged
-        .withName("SortMergeRollupAndCountDuplicates")
-        .transform {
-          _.filter(_._1)
-            .map(_._2)
-            .sumByKey
-            .flatMap { case (dims @ (_, rollupDims), measure) =>
-              rollupFunction(rollupDims)
-                .map((x: R) => dims.copy(_2 = x) -> measure)
-            }
-        }
-
-      // Branch 2 (correction): already in rolled-up space, no expansion needed.
-      val corrections = tagged
-        .withName("SortMergeRollupAndCountCorrection")
-        .transform {
-          _.filter(!_._1)
-            .map(_._2)
-        }
-
-      SCollection
-        .unionAll(List(main, corrections))
-        .withName("SortMergeRollupAndCountCorrected")
-        .sumByKey
+        .rollupAndCount(rollupFunction)
     }
   }
 

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
@@ -133,14 +133,17 @@ trait SCollectionSyntax extends SortMergeBucketScioContextSyntax {
         .sortMergeGroupByKey(keyClass, read, targetParallelism)
         .withName("SortMergeRollupAndCount")
         .flatMap { case (key, values) =>
-          // Accumulate only (D → List[R]) for corrections — measures not needed (g.zero)
-          val correctionState = new collection.mutable.HashMap[D, collection.mutable.ArrayBuffer[R]]()
+          // Accumulate (D → (R → count)) for corrections — track distinct R values per D,
+          // counting duplicates so the correction logic handles repeated (D, R) tuples correctly.
+          val correctionState =
+            new collection.mutable.HashMap[D, collection.mutable.HashMap[R, Long]]()
 
           // Phase 1: stream through lazy iterator, yield main records one at a time.
-          // Side-effect: accumulate R values per D for correction computation.
+          // Side-effect: accumulate R occurrence counts per D for correction computation.
           val mainIter = values.iterator.map { v =>
             val (d, r, m) = extractFn(key, v)
-            correctionState.getOrElseUpdate(d, new collection.mutable.ArrayBuffer[R]()) += r
+            val rCounts = correctionState.getOrElseUpdate(d, new collection.mutable.HashMap[R, Long]())
+            rCounts(r) = rCounts.getOrElse(r, 0L) + 1L
             (true, ((d, r), (m, 1L)))
           }
 
@@ -151,11 +154,12 @@ trait SCollectionSyntax extends SortMergeBucketScioContextSyntax {
 
             private def ensureInit(): Unit = {
               if (inner == null) {
-                inner = correctionState.iterator.flatMap { case (d, rs) =>
-                  if (rs.size <= 1) Iterator.empty
+                inner = correctionState.iterator.flatMap { case (d, rCounts) =>
+                  // Only need corrections when there are multiple distinct R values per D
+                  if (rCounts.size <= 1) Iterator.empty
                   else {
                     val rollupMap = collection.mutable.Map.empty[R, Long]
-                    for (r <- rs; r2 <- rollupFunction(r)) {
+                    for ((r, _) <- rCounts; r2 <- rollupFunction(r)) {
                       rollupMap(r2) = rollupMap.getOrElse(r2, 1L) - 1L
                     }
                     rollupMap.iterator.collect {

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
@@ -129,44 +129,57 @@ trait SCollectionSyntax extends SortMergeBucketScioContextSyntax {
       targetParallelism: TargetParallelism = TargetParallelism.auto()
     )(implicit g: Group[M]): SCollection[((D, R), (M, Long))] = {
 
-      val grouped = self.sortMergeGroupByKey(keyClass, read, targetParallelism)
+      // Single flatMap consumes the lazy SMB iterable once via perKeyFn (which returns Seq).
+      // Emits tagged records: true = main (un-expanded), false = correction (already expanded).
+      val tagged = self
+        .sortMergeGroupByKey(keyClass, read, targetParallelism)
+        .withName("SortMergeRollupAndCount")
+        .flatMap { case (key, values) =>
+          val tuples = perKeyFn(key, values)
 
-      // Branch 1 (main): unchanged from rollupAndCount.
-      // Aggregate to metric level first, then expand rollups on the small result.
-      val main = grouped
+          val main = tuples.iterator.map { case (d, r, m) =>
+            (true, ((d, r), (m, 1L)))
+          }
+
+          val corrections = tuples
+            .groupBy(_._1)
+            .iterator
+            .flatMap { case (d, byD) =>
+              if (byD.size <= 1) Iterator.empty
+              else {
+                val rollupMap = collection.mutable.Map.empty[R, Long]
+                for ((_, r, _) <- byD; r2 <- rollupFunction(r)) {
+                  rollupMap(r2) = rollupMap.getOrElse(r2, 1L) - 1L
+                }
+                rollupMap.iterator.collect {
+                  case (r2, count) if count < 0L =>
+                    (false, ((d, r2), (g.zero, count)))
+                }
+              }
+            }
+
+          main ++ corrections
+        }
+
+      // Branch 1 (main): sum metric first (massive reduction), then expand rollups.
+      val main = tagged
         .withName("SortMergeRollupAndCountDuplicates")
         .transform {
-          _.flatMap { case (key, values) =>
-            perKeyFn(key, values).map { case (d, r, m) => ((d, r), (m, 1L)) }
-          }.sumByKey
+          _.filter(_._1)
+            .map(_._2)
+            .sumByKey
             .flatMap { case (dims @ (_, rollupDims), measure) =>
               rollupFunction(rollupDims)
                 .map((x: R) => dims.copy(_2 = x) -> measure)
             }
         }
 
-      // Branch 2 (correction): SMB-optimized — computed locally per key, no shuffle.
-      val corrections = grouped
+      // Branch 2 (correction): already in rolled-up space, no expansion needed.
+      val corrections = tagged
         .withName("SortMergeRollupAndCountCorrection")
         .transform {
-          _.flatMap { case (key, values) =>
-            val tuples = perKeyFn(key, values)
-            tuples
-              .groupBy(_._1)
-              .iterator
-              .flatMap { case (d, byD) =>
-                if (byD.size <= 1) Iterator.empty
-                else {
-                  val rollupMap = collection.mutable.Map.empty[R, Long]
-                  for ((_, r, _) <- byD; r2 <- rollupFunction(r)) {
-                    rollupMap(r2) = rollupMap.getOrElse(r2, 1L) - 1L
-                  }
-                  rollupMap.iterator.collect {
-                    case (r2, count) if count < 0L => ((d, r2), (g.zero, count))
-                  }
-                }
-              }
-          }
+          _.filter(!_._1)
+            .map(_._2)
         }
 
       SCollection

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
@@ -105,17 +105,16 @@ trait SCollectionSyntax extends SortMergeBucketScioContextSyntax {
      * `sortMergeGroupByKey` already delivers all records per key to the same worker, so corrections
      * can be computed locally without a shuffle.
      *
-     * Emits tagged records from a single flatMap: main records (un-expanded) go through `sumByKey`
-     * then rollup expansion; correction records (already in rolled-up space) skip expansion and go
-     * directly to the final `sumByKey`.
+     * Streams through the lazy SMB iterable once per key. Main records are emitted as the iterator
+     * is consumed; only `(D -> List[R])` is accumulated in memory for computing corrections.
+     * After the iterator is exhausted, correction records are emitted.
      *
      * @param keyClass
      *   SMB key class (= unique key to count distinct, typically userId)
      * @param read
      *   SMB read configuration
-     * @param perKeyFn
-     *   per-key extraction function: given a key and all its records, produce `(D, R, M)` tuples.
-     *   The lazy SMB iterable is consumed once by this function.
+     * @param extractFn
+     *   per-record extraction function: given a key and one record, produce a `(D, R, M)` tuple
      * @param rollupFunction
      *   rollup expansion function (same as in [[RollupOps.rollupAndCount]])
      * @param targetParallelism
@@ -125,44 +124,54 @@ trait SCollectionSyntax extends SortMergeBucketScioContextSyntax {
     def sortMergeRollupAndCount[K: Coder, V: Coder, D: Coder, R: Coder, M: Coder](
       keyClass: Class[K],
       read: SortedBucketIO.Read[V],
-      perKeyFn: (K, Iterable[V]) => Seq[(D, R, M)],
+      extractFn: (K, V) => (D, R, M),
       rollupFunction: R => Set[R],
       targetParallelism: TargetParallelism = TargetParallelism.auto()
     )(implicit g: Group[M]): SCollection[((D, R), (M, Long))] = {
 
-      // Single flatMap consumes the lazy SMB iterable once via perKeyFn.
-      // Emits tagged records: true = main (un-expanded), false = correction (already expanded).
       val tagged = self
         .sortMergeGroupByKey(keyClass, read, targetParallelism)
         .withName("SortMergeRollupAndCount")
         .flatMap { case (key, values) =>
-          val tuples = perKeyFn(key, values)
+          // Accumulate only (D → List[R]) for corrections — measures not needed (g.zero)
+          val correctionState = new collection.mutable.HashMap[D, collection.mutable.ArrayBuffer[R]]()
 
-          // Main: un-expanded (D, R) with measure and userCount=1
-          val main = tuples.iterator.map { case (d, r, m) =>
+          // Phase 1: stream through lazy iterator, yield main records one at a time.
+          // Side-effect: accumulate R values per D for correction computation.
+          val mainIter = values.iterator.map { v =>
+            val (d, r, m) = extractFn(key, v)
+            correctionState.getOrElseUpdate(d, new collection.mutable.ArrayBuffer[R]()) += r
             (true, ((d, r), (m, 1L)))
           }
 
-          // Correction: group by D locally (no shuffle), compute corrections
-          // in rolled-up R space for users with multiple R values per D
-          val corrections = tuples
-            .groupBy(_._1)
-            .iterator
-            .flatMap { case (d, byD) =>
-              if (byD.size <= 1) Iterator.empty
-              else {
-                val rollupMap = collection.mutable.Map.empty[R, Long]
-                for ((_, r, _) <- byD; r2 <- rollupFunction(r)) {
-                  rollupMap(r2) = rollupMap.getOrElse(r2, 1L) - 1L
-                }
-                rollupMap.iterator.collect {
-                  case (r2, count) if count < 0L =>
-                    (false, ((d, r2), (g.zero, count)))
+          // Phase 2: after main iterator is exhausted, compute and yield corrections.
+          // Uses lazy iterator — corrections are computed on first access after main is done.
+          val correctionIter = new Iterator[(Boolean, ((D, R), (M, Long)))] {
+            private var inner: Iterator[(Boolean, ((D, R), (M, Long)))] = _
+
+            private def ensureInit(): Unit = {
+              if (inner == null) {
+                inner = correctionState.iterator.flatMap { case (d, rs) =>
+                  if (rs.size <= 1) Iterator.empty
+                  else {
+                    val rollupMap = collection.mutable.Map.empty[R, Long]
+                    for (r <- rs; r2 <- rollupFunction(r)) {
+                      rollupMap(r2) = rollupMap.getOrElse(r2, 1L) - 1L
+                    }
+                    rollupMap.iterator.collect {
+                      case (r2, count) if count < 0L =>
+                        (false, ((d, r2), (g.zero, count)))
+                    }
+                  }
                 }
               }
             }
 
-          main ++ corrections
+            override def hasNext: Boolean = { ensureInit(); inner.hasNext }
+            override def next(): (Boolean, ((D, R), (M, Long))) = { ensureInit(); inner.next() }
+          }
+
+          mainIter ++ correctionIter
         }
 
       // Branch 1 (main): sum metric first (massive reduction), then expand rollups.

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
@@ -96,18 +96,26 @@ trait SCollectionSyntax extends SortMergeBucketScioContextSyntax {
       extends Serializable {
 
     /**
-     * SMB-aware variant of [[RollupOps.rollupAndCount]] that reads from sort-merge buckets.
+     * SMB-optimized variant of [[RollupOps.rollupAndCount]] that eliminates the expensive
+     * correction branch shuffle by leveraging sort-merge bucket co-location.
      *
-     * Reads SMB-keyed data via `sortMergeGroupByKey`, consumes the (potentially lazy) per-key
-     * iterable once via `perKeyFn`, and extracts `(U, D, R, M)` tuples that are then processed
-     * by the standard [[RollupOps.rollupAndCount]].
+     * In the general [[RollupOps.rollupAndCount]], the correction branch requires a `groupByKey` on
+     * `(uniqueKey, D)` to detect double-counted users across rollup dimensions — this shuffle is
+     * typically the dominant cost. When the input is SMB-keyed by the unique key,
+     * `sortMergeGroupByKey` already delivers all records per key to the same worker, so corrections
+     * can be computed locally without a shuffle.
+     *
+     * Emits tagged records from a single flatMap: main records (un-expanded) go through `sumByKey`
+     * then rollup expansion; correction records (already in rolled-up space) skip expansion and go
+     * directly to the final `sumByKey`.
      *
      * @param keyClass
      *   SMB key class (= unique key to count distinct, typically userId)
      * @param read
      *   SMB read configuration
      * @param perKeyFn
-     *   per-key extraction function: given a key and all its records, produce `(D, R, M)` tuples
+     *   per-key extraction function: given a key and all its records, produce `(D, R, M)` tuples.
+     *   The lazy SMB iterable is consumed once by this function.
      * @param rollupFunction
      *   rollup expansion function (same as in [[RollupOps.rollupAndCount]])
      * @param targetParallelism
@@ -122,12 +130,66 @@ trait SCollectionSyntax extends SortMergeBucketScioContextSyntax {
       targetParallelism: TargetParallelism = TargetParallelism.auto()
     )(implicit g: Group[M]): SCollection[((D, R), (M, Long))] = {
 
-      self
+      // Single flatMap consumes the lazy SMB iterable once via perKeyFn.
+      // Emits tagged records: true = main (un-expanded), false = correction (already expanded).
+      val tagged = self
         .sortMergeGroupByKey(keyClass, read, targetParallelism)
+        .withName("SortMergeRollupAndCount")
         .flatMap { case (key, values) =>
-          perKeyFn(key, values).map { case (d, r, m) => (key, d, r, m) }
+          val tuples = perKeyFn(key, values)
+
+          // Main: un-expanded (D, R) with measure and userCount=1
+          val main = tuples.iterator.map { case (d, r, m) =>
+            (true, ((d, r), (m, 1L)))
+          }
+
+          // Correction: group by D locally (no shuffle), compute corrections
+          // in rolled-up R space for users with multiple R values per D
+          val corrections = tuples
+            .groupBy(_._1)
+            .iterator
+            .flatMap { case (d, byD) =>
+              if (byD.size <= 1) Iterator.empty
+              else {
+                val rollupMap = collection.mutable.Map.empty[R, Long]
+                for ((_, r, _) <- byD; r2 <- rollupFunction(r)) {
+                  rollupMap(r2) = rollupMap.getOrElse(r2, 1L) - 1L
+                }
+                rollupMap.iterator.collect {
+                  case (r2, count) if count < 0L =>
+                    (false, ((d, r2), (g.zero, count)))
+                }
+              }
+            }
+
+          main ++ corrections
         }
-        .rollupAndCount(rollupFunction)
+
+      // Branch 1 (main): sum metric first (massive reduction), then expand rollups.
+      val main = tagged
+        .withName("SortMergeRollupAndCountDuplicates")
+        .transform {
+          _.filter(_._1)
+            .map(_._2)
+            .sumByKey
+            .flatMap { case (dims @ (_, rollupDims), measure) =>
+              rollupFunction(rollupDims)
+                .map((x: R) => dims.copy(_2 = x) -> measure)
+            }
+        }
+
+      // Branch 2 (correction): already in rolled-up space, no expansion needed.
+      val corrections = tagged
+        .withName("SortMergeRollupAndCountCorrection")
+        .transform {
+          _.filter(!_._1)
+            .map(_._2)
+        }
+
+      SCollection
+        .unionAll(List(main, corrections))
+        .withName("SortMergeRollupAndCountCorrected")
+        .sumByKey
     }
   }
 

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
@@ -133,8 +133,8 @@ trait SCollectionSyntax extends SortMergeBucketScioContextSyntax {
         .sortMergeGroupByKey(keyClass, read, targetParallelism)
         .withName("SortMergeRollupAndCount")
         .flatMap { case (key, values) =>
-          // Accumulate (D → (R → count)) for corrections — track distinct R values per D,
-          // counting duplicates so the correction logic handles repeated (D, R) tuples correctly.
+          // Accumulate (D → (R → count)) for corrections — track R occurrences per D
+          // so duplicates contribute proportionally to corrections.
           val correctionState =
             new collection.mutable.HashMap[D, collection.mutable.HashMap[R, Long]]()
 
@@ -148,18 +148,20 @@ trait SCollectionSyntax extends SortMergeBucketScioContextSyntax {
           }
 
           // Phase 2: after main iterator is exhausted, compute and yield corrections.
-          // Uses lazy iterator — corrections are computed on first access after main is done.
+          // Mirrors the original rollupAndCount correction logic: each occurrence of R
+          // decrements the rollup map by 1 (starting from 1), so n occurrences of the
+          // same R produce a net correction of -(n-1) for each rolled-up dimension.
           val correctionIter = new Iterator[(Boolean, ((D, R), (M, Long)))] {
             private var inner: Iterator[(Boolean, ((D, R), (M, Long)))] = _
 
             private def ensureInit(): Unit = {
               if (inner == null) {
                 inner = correctionState.iterator.flatMap { case (d, rCounts) =>
-                  // Only need corrections when there are multiple distinct R values per D
-                  if (rCounts.size <= 1) Iterator.empty
+                  val totalRecords = rCounts.values.sum
+                  if (totalRecords <= 1) Iterator.empty
                   else {
                     val rollupMap = collection.mutable.Map.empty[R, Long]
-                    for ((r, _) <- rCounts; r2 <- rollupFunction(r)) {
+                    for ((r, count) <- rCounts; _ <- 0L until count; r2 <- rollupFunction(r)) {
                       rollupMap(r2) = rollupMap.getOrElse(r2, 1L) - 1L
                     }
                     rollupMap.iterator.collect {

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/rollup/syntax/SCollectionSyntax.scala
@@ -17,11 +17,15 @@
 
 package com.spotify.scio.extra.rollup.syntax
 
-import com.spotify.scio.coders.BeamCoders
+import com.spotify.scio.ScioContext
+import com.spotify.scio.annotations.experimental
+import com.spotify.scio.coders.{BeamCoders, Coder}
+import com.spotify.scio.smb.syntax.SortMergeBucketScioContextSyntax
 import com.spotify.scio.values.SCollection
 import com.twitter.algebird.Group
+import org.apache.beam.sdk.extensions.smb.{SortedBucketIO, TargetParallelism}
 
-trait SCollectionSyntax {
+trait SCollectionSyntax extends SortMergeBucketScioContextSyntax {
 
   implicit final class RollupOps[U, D, R, M](self: SCollection[(U, D, R, M)]) {
 
@@ -72,11 +76,9 @@ trait SCollectionSyntax {
               val rollupMap = collection.mutable.Map.empty[R, Long]
               for (r <- values) {
                 for (newDim <- rollupFunction(r)) {
-                  // Add 1 to correction count. We only care to correct for excessive counts
                   rollupMap(newDim) = rollupMap.getOrElse(newDim, 1L) - 1L
                 }
               }
-              // We only care about correcting cases where we actually double-count
               rollupMap.iterator.filter(_._2 < 0L)
             }
             .map { case ((_, dims), (rollupDims, count)) => ((dims, rollupDims), (g.zero, count)) }
@@ -87,6 +89,90 @@ trait SCollectionSyntax {
         .withName("RollupAndCountCorrected")
         .sumByKey
 
+    }
+  }
+
+  implicit final class SortMergeRollupOps(@transient private val self: ScioContext)
+      extends Serializable {
+
+    /**
+     * SMB-optimized variant of [[RollupOps.rollupAndCount]] that eliminates the expensive
+     * correction branch shuffle by leveraging sort-merge bucket co-location.
+     *
+     * In the general [[RollupOps.rollupAndCount]], the correction branch requires a `groupByKey` on
+     * `(uniqueKey, D)` to detect double-counted users across rollup dimensions — this shuffle is
+     * typically the dominant cost. When the input is SMB-keyed by the unique key,
+     * `sortMergeGroupByKey` already delivers all records per key to the same worker, so corrections
+     * can be computed locally without a shuffle.
+     *
+     * Branch 1 (main) is unchanged: drop unique key, aggregate to metric level via `sumByKey`,
+     * then expand rollup dimensions on the small aggregated data. Branch 2 (correction) replaces
+     * the `groupByKey` with a local per-key computation inside the SMB read.
+     *
+     * @param keyClass
+     *   SMB key class (= unique key to count distinct, typically userId)
+     * @param read
+     *   SMB read configuration
+     * @param perKeyFn
+     *   per-key extraction function: given a key and all its records, produce `(D, R, M)` tuples
+     * @param rollupFunction
+     *   rollup expansion function (same as in [[RollupOps.rollupAndCount]])
+     * @param targetParallelism
+     *   SMB read parallelism
+     */
+    @experimental
+    def sortMergeRollupAndCount[K: Coder, V: Coder, D: Coder, R: Coder, M: Coder](
+      keyClass: Class[K],
+      read: SortedBucketIO.Read[V],
+      perKeyFn: (K, Iterable[V]) => Seq[(D, R, M)],
+      rollupFunction: R => Set[R],
+      targetParallelism: TargetParallelism = TargetParallelism.auto()
+    )(implicit g: Group[M]): SCollection[((D, R), (M, Long))] = {
+
+      val grouped = self.sortMergeGroupByKey(keyClass, read, targetParallelism)
+
+      // Branch 1 (main): unchanged from rollupAndCount.
+      // Aggregate to metric level first, then expand rollups on the small result.
+      val main = grouped
+        .withName("SortMergeRollupAndCountDuplicates")
+        .transform {
+          _.flatMap { case (key, values) =>
+            perKeyFn(key, values).map { case (d, r, m) => ((d, r), (m, 1L)) }
+          }.sumByKey
+            .flatMap { case (dims @ (_, rollupDims), measure) =>
+              rollupFunction(rollupDims)
+                .map((x: R) => dims.copy(_2 = x) -> measure)
+            }
+        }
+
+      // Branch 2 (correction): SMB-optimized — computed locally per key, no shuffle.
+      val corrections = grouped
+        .withName("SortMergeRollupAndCountCorrection")
+        .transform {
+          _.flatMap { case (key, values) =>
+            val tuples = perKeyFn(key, values)
+            tuples
+              .groupBy(_._1)
+              .iterator
+              .flatMap { case (d, byD) =>
+                if (byD.size <= 1) Iterator.empty
+                else {
+                  val rollupMap = collection.mutable.Map.empty[R, Long]
+                  for ((_, r, _) <- byD; r2 <- rollupFunction(r)) {
+                    rollupMap(r2) = rollupMap.getOrElse(r2, 1L) - 1L
+                  }
+                  rollupMap.iterator.collect {
+                    case (r2, count) if count < 0L => ((d, r2), (g.zero, count))
+                  }
+                }
+              }
+          }
+        }
+
+      SCollection
+        .unionAll(List(main, corrections))
+        .withName("SortMergeRollupAndCountCorrected")
+        .sumByKey
     }
   }
 

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/rollup/SortMergeRollupTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/rollup/SortMergeRollupTest.scala
@@ -43,17 +43,15 @@ object SortMergeRollupTest {
       .read(new TupleTag[Account]("accounts"), classOf[Account])
       .from(path)
 
-  def perKeyFn(
+  def extractFn(
     @annotation.unused key: Integer,
-    accounts: Iterable[Account]
-  ): Seq[(String, RollupDims, Measure)] =
-    accounts.map { a =>
-      (
-        a.getName.toString,
-        RollupDims(accountType = Some(a.getType.toString)),
-        Measure(a.getAmount.toLong)
-      )
-    }.toSeq
+    a: Account
+  ): (String, RollupDims, Measure) =
+    (
+      a.getName.toString,
+      RollupDims(accountType = Some(a.getType.toString)),
+      Measure(a.getAmount.toLong)
+    )
 
   def mkAccount(id: Int, tpe: String, name: String, amount: Double): Account =
     Account
@@ -75,7 +73,7 @@ object SortMergeRollupJob {
     sc.sortMergeRollupAndCount(
       classOf[Integer],
       avroRead(args("input")),
-      perKeyFn,
+      extractFn,
       groupingSets
     ).map { case ((name, dims), (measure, count)) =>
         s"$name|${dims.accountType.getOrElse("ALL")}|${measure.amount}|$count"

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/rollup/SortMergeRollupTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/rollup/SortMergeRollupTest.scala
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2025 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.extra.rollup
+
+import com.spotify.scio.avro.{Account, AccountStatus}
+import com.spotify.scio.ContextAndArgs
+import com.spotify.scio.io.TextIO
+import com.spotify.scio.smb.SmbIO
+import com.spotify.scio.testing._
+import com.twitter.algebird.Group
+import com.twitter.algebird.macros.caseclass
+import org.apache.beam.sdk.extensions.smb.AvroSortedBucketIO
+import org.apache.beam.sdk.values.TupleTag
+
+object SortMergeRollupTest {
+  case class Measure(amount: Long)
+  implicit val measureGroup: Group[Measure] = caseclass.group
+
+  case class RollupDims(accountType: Option[String])
+
+  def groupingSets(dims: RollupDims): Set[RollupDims] =
+    (for {
+      accountType <- List(dims.copy(accountType = None), dims)
+    } yield accountType).toSet
+
+  def avroRead(path: String): AvroSortedBucketIO.Read[Account] =
+    AvroSortedBucketIO
+      .read(new TupleTag[Account]("accounts"), classOf[Account])
+      .from(path)
+
+  def perKeyFn(
+    @annotation.unused key: Integer,
+    accounts: Iterable[Account]
+  ): Seq[(String, RollupDims, Measure)] =
+    accounts.map { a =>
+      (
+        a.getName.toString,
+        RollupDims(accountType = Some(a.getType.toString)),
+        Measure(a.getAmount.toLong)
+      )
+    }.toSeq
+
+  def mkAccount(id: Int, tpe: String, name: String, amount: Double): Account =
+    Account
+      .newBuilder()
+      .setId(id)
+      .setType(tpe)
+      .setName(name)
+      .setAmount(amount)
+      .setAccountStatus(AccountStatus.Active)
+      .build()
+}
+
+object SortMergeRollupJob {
+  import SortMergeRollupTest._
+
+  def main(cmdlineArgs: Array[String]): Unit = {
+    val (sc, args) = ContextAndArgs(cmdlineArgs)
+
+    sc.sortMergeRollupAndCount(
+      classOf[Integer],
+      avroRead(args("input")),
+      perKeyFn,
+      groupingSets
+    ).map { case ((name, dims), (measure, count)) =>
+        s"$name|${dims.accountType.getOrElse("ALL")}|${measure.amount}|$count"
+      }
+      .saveAsTextFile(args("output"))
+
+    sc.run().waitUntilDone()
+  }
+}
+
+class SortMergeRollupTest extends PipelineSpec {
+  import SortMergeRollupTest._
+
+  "sortMergeRollupAndCount" should "not double-count a user with multiple rollup dimensions" in {
+    val input = Seq(
+      mkAccount(1, "checking", "fixed-dim", 100.0),
+      mkAccount(1, "savings", "fixed-dim", 200.0)
+    )
+
+    JobTest[SortMergeRollupJob.type]
+      .args("--input=gs://input", "--output=gs://output")
+      .input(SmbIO[Integer, Account]("gs://input", _.getId), input)
+      .output(TextIO("gs://output")) { out =>
+        out should containInAnyOrder(
+          Seq(
+            "fixed-dim|checking|100|1",
+            "fixed-dim|savings|200|1",
+            "fixed-dim|ALL|300|1"
+          )
+        )
+      }
+      .run()
+  }
+
+  it should "correctly count multiple users across cohorts" in {
+    val input = Seq(
+      mkAccount(1, "checking", "fixed-dim", 100.0),
+      mkAccount(1, "savings", "fixed-dim", 200.0),
+      mkAccount(2, "savings", "fixed-dim", 300.0)
+    )
+
+    JobTest[SortMergeRollupJob.type]
+      .args("--input=gs://input", "--output=gs://output")
+      .input(SmbIO[Integer, Account]("gs://input", _.getId), input)
+      .output(TextIO("gs://output")) { out =>
+        out should containInAnyOrder(
+          Seq(
+            "fixed-dim|checking|100|1",
+            "fixed-dim|savings|500|2",
+            "fixed-dim|ALL|600|2"
+          )
+        )
+      }
+      .run()
+  }
+
+  it should "work with empty input" in {
+    JobTest[SortMergeRollupJob.type]
+      .args("--input=gs://input", "--output=gs://output")
+      .input(SmbIO[Integer, Account]("gs://input", _.getId), Seq.empty[Account])
+      .output(TextIO("gs://output"))(_.should(beEmpty))
+      .run()
+  }
+
+  it should "handle single user single cohort" in {
+    val input = Seq(mkAccount(1, "checking", "fixed-dim", 100.0))
+
+    JobTest[SortMergeRollupJob.type]
+      .args("--input=gs://input", "--output=gs://output")
+      .input(SmbIO[Integer, Account]("gs://input", _.getId), input)
+      .output(TextIO("gs://output")) { out =>
+        out should containInAnyOrder(
+          Seq(
+            "fixed-dim|checking|100|1",
+            "fixed-dim|ALL|100|1"
+          )
+        )
+      }
+      .run()
+  }
+
+  it should "separate on fixed dimensions" in {
+    val input = Seq(
+      mkAccount(1, "checking", "group-A", 100.0),
+      mkAccount(1, "checking", "group-B", 200.0)
+    )
+
+    JobTest[SortMergeRollupJob.type]
+      .args("--input=gs://input", "--output=gs://output")
+      .input(SmbIO[Integer, Account]("gs://input", _.getId), input)
+      .output(TextIO("gs://output")) { out =>
+        out should containInAnyOrder(
+          Seq(
+            "group-A|checking|100|1",
+            "group-A|ALL|100|1",
+            "group-B|checking|200|1",
+            "group-B|ALL|200|1"
+          )
+        )
+      }
+      .run()
+  }
+
+  it should "produce identical results to rollupAndCount" in {
+    val smbInput = Seq(
+      mkAccount(1, "web", "2020-01-01", 100.0),
+      mkAccount(1, "mobile", "2020-01-01", 200.0),
+      mkAccount(2, "speaker", "2020-01-01", 200.0)
+    )
+
+    // Compute expected via rollupAndCount for comparison
+    val rollupExpected = runWithData(
+      Seq(
+        (1: Integer, "2020-01-01", RollupDims(Some("web")), Measure(100L)),
+        (1: Integer, "2020-01-01", RollupDims(Some("mobile")), Measure(200L)),
+        (2: Integer, "2020-01-01", RollupDims(Some("speaker")), Measure(200L))
+      )
+    )(_.rollupAndCount(groupingSets)).map { case ((name, dims), (measure, count)) =>
+      s"$name|${dims.accountType.getOrElse("ALL")}|${measure.amount}|$count"
+    }
+
+    JobTest[SortMergeRollupJob.type]
+      .args("--input=gs://input", "--output=gs://output")
+      .input(SmbIO[Integer, Account]("gs://input", _.getId), smbInput)
+      .output(TextIO("gs://output")) { out =>
+        out should containInAnyOrder(rollupExpected)
+      }
+      .run()
+  }
+}

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/MultiSourceKeyGroupReader.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/MultiSourceKeyGroupReader.java
@@ -21,10 +21,12 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.beam.sdk.extensions.smb.SortedBucketIO.ComparableKeyBytes;
+import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.Metrics;
@@ -79,6 +81,32 @@ public class MultiSourceKeyGroupReader<KeyType> {
       int bucketId,
       int effectiveParallelism,
       PipelineOptions options) {
+    this(
+        sources,
+        keyFn,
+        resultSchema,
+        someArbitraryBucketMetadata,
+        keyComparator,
+        metricsPrefix,
+        materializeKeyGroup,
+        bucketId,
+        effectiveParallelism,
+        options,
+        null);
+  }
+
+  public MultiSourceKeyGroupReader(
+      List<SortedBucketSource.BucketedInput<?>> sources,
+      Function<ComparableKeyBytes, KeyType> keyFn,
+      CoGbkResultSchema resultSchema,
+      BucketMetadata<?, ?, ?> someArbitraryBucketMetadata,
+      Comparator<ComparableKeyBytes> keyComparator,
+      String metricsPrefix,
+      boolean materializeKeyGroup,
+      int bucketId,
+      int effectiveParallelism,
+      PipelineOptions options,
+      Map<TupleTag<?>, Set<ResourceId>> directoryFilters) {
     this.keyFn = keyFn;
     this.keyGroupSize = Metrics.distribution(metricsPrefix, metricsPrefix + "-KeyGroupSize");
     this.predicateFilteredRecordsCounts =
@@ -97,7 +125,12 @@ public class MultiSourceKeyGroupReader<KeyType> {
     this.resultSchema = resultSchema;
     this.bucketedInputs =
         sources.stream()
-            .map(src -> new BucketIterator<>(src, bucketId, effectiveParallelism, options))
+            .map(
+                src -> {
+                  Set<ResourceId> filter =
+                      directoryFilters != null ? directoryFilters.get(src.tupleTag) : null;
+                  return new BucketIterator<>(src, bucketId, effectiveParallelism, options, filter);
+                })
             .collect(Collectors.toList());
     // this only operates on the primary key
     this.keyGroupFilter =
@@ -254,9 +287,18 @@ public class MultiSourceKeyGroupReader<KeyType> {
         int bucketId,
         int parallelism,
         PipelineOptions options) {
+      this(source, bucketId, parallelism, options, null);
+    }
+
+    BucketIterator(
+        SortedBucketSource.BucketedInput<V> source,
+        int bucketId,
+        int parallelism,
+        PipelineOptions options,
+        Set<ResourceId> directoryFilter) {
       this.predicate = source.getPredicate();
       this.tupleTag = source.getTupleTag();
-      this.iter = source.createIterator(bucketId, parallelism, options);
+      this.iter = source.createIterator(bucketId, parallelism, options, directoryFilter);
 
       int numBuckets = source.getSourceMetadata().leastNumBuckets();
       // The canonical # buckets for this source. If # buckets >= the parallelism of the job,

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -148,16 +148,27 @@ public class SortedBucketIO {
     private final List<BucketedInput<?>> inputs;
     private final TargetParallelism targetParallelism;
     private final String metricsKey;
+    private final boolean lazyKeyGroups;
 
     private CoGbk(
         Class<K> keyClass,
         List<BucketedInput<?>> inputs,
         TargetParallelism targetParallelism,
         String metricsKey) {
+      this(keyClass, inputs, targetParallelism, metricsKey, false);
+    }
+
+    private CoGbk(
+        Class<K> keyClass,
+        List<BucketedInput<?>> inputs,
+        TargetParallelism targetParallelism,
+        String metricsKey,
+        boolean lazyKeyGroups) {
       this.keyClass = keyClass;
       this.inputs = inputs;
       this.targetParallelism = targetParallelism;
       this.metricsKey = metricsKey;
+      this.lazyKeyGroups = lazyKeyGroups;
     }
 
     /**
@@ -171,15 +182,24 @@ public class SortedBucketIO {
               .add(read.toBucketedInput(SortedBucketSource.Keying.PRIMARY))
               .build();
       validateInputNameUniqueness(newReads);
-      return new CoGbk<>(keyClass, newReads, targetParallelism, metricsKey);
+      return new CoGbk<>(keyClass, newReads, targetParallelism, metricsKey, lazyKeyGroups);
     }
 
     public CoGbk<K> withTargetParallelism(TargetParallelism targetParallelism) {
-      return new CoGbk<>(keyClass, inputs, targetParallelism, metricsKey);
+      return new CoGbk<>(keyClass, inputs, targetParallelism, metricsKey, lazyKeyGroups);
     }
 
     public CoGbk<K> withMetricsKey(String metricsKey) {
-      return new CoGbk<>(keyClass, inputs, targetParallelism, metricsKey);
+      return new CoGbk<>(keyClass, inputs, targetParallelism, metricsKey, lazyKeyGroups);
+    }
+
+    /**
+     * When enabled, key group iterables in the CoGbkResult are lazily evaluated instead of eagerly
+     * materialized into Lists. This reduces memory usage for large key groups but means each
+     * Iterable can only be traversed once.
+     */
+    public CoGbk<K> withLazyKeyGroups(boolean lazy) {
+      return new CoGbk<>(keyClass, inputs, targetParallelism, metricsKey, lazy);
     }
 
     public <V> CoGbkTransform<K, V> transform(TransformOutput<K, Void, V> transform) {
@@ -188,10 +208,10 @@ public class SortedBucketIO {
 
     @Override
     public PCollection<KV<K, CoGbkResult>> expand(PBegin input) {
-      return input.apply(
-          org.apache.beam.sdk.io.Read.from(
-              new SortedBucketPrimaryKeyedSource<>(
-                  keyClass, inputs, targetParallelism, metricsKey)));
+      SortedBucketPrimaryKeyedSource<K> source =
+          new SortedBucketPrimaryKeyedSource<>(keyClass, inputs, targetParallelism, metricsKey);
+      source.lazyKeyGroups = this.lazyKeyGroups;
+      return input.apply(org.apache.beam.sdk.io.Read.from(source));
     }
   }
 
@@ -207,6 +227,7 @@ public class SortedBucketIO {
     private final List<BucketedInput<?>> inputs;
     private final TargetParallelism targetParallelism;
     private final String metricsKey;
+    private final boolean lazyKeyGroups;
 
     private CoGbkWithSecondary(
         Class<K1> keyClassPrimary,
@@ -214,11 +235,22 @@ public class SortedBucketIO {
         List<BucketedInput<?>> inputs,
         TargetParallelism targetParallelism,
         String metricsKey) {
+      this(keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey, false);
+    }
+
+    private CoGbkWithSecondary(
+        Class<K1> keyClassPrimary,
+        Class<K2> keyClassSecondary,
+        List<BucketedInput<?>> inputs,
+        TargetParallelism targetParallelism,
+        String metricsKey,
+        boolean lazyKeyGroups) {
       this.keyClassPrimary = keyClassPrimary;
       this.keyClassSecondary = keyClassSecondary;
       this.inputs = inputs;
       this.targetParallelism = targetParallelism;
       this.metricsKey = metricsKey;
+      this.lazyKeyGroups = lazyKeyGroups;
     }
 
     /**
@@ -233,17 +265,27 @@ public class SortedBucketIO {
               .build();
       validateInputNameUniqueness(newReads);
       return new CoGbkWithSecondary<>(
-          keyClassPrimary, keyClassSecondary, newReads, targetParallelism, metricsKey);
+          keyClassPrimary,
+          keyClassSecondary,
+          newReads,
+          targetParallelism,
+          metricsKey,
+          lazyKeyGroups);
     }
 
     public CoGbkWithSecondary<K1, K2> withTargetParallelism(TargetParallelism targetParallelism) {
       return new CoGbkWithSecondary<>(
-          keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey);
+          keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey, lazyKeyGroups);
     }
 
     public CoGbkWithSecondary<K1, K2> withMetricsKey(String metricsKey) {
       return new CoGbkWithSecondary<>(
-          keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey);
+          keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey, lazyKeyGroups);
+    }
+
+    public CoGbkWithSecondary<K1, K2> withLazyKeyGroups(boolean lazy) {
+      return new CoGbkWithSecondary<>(
+          keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey, lazy);
     }
 
     public <V> CoGbkTransformWithSecondary<K1, K2, V> transform(
@@ -254,10 +296,11 @@ public class SortedBucketIO {
 
     @Override
     public PCollection<KV<KV<K1, K2>, CoGbkResult>> expand(PBegin input) {
-      return input.apply(
-          org.apache.beam.sdk.io.Read.from(
-              new SortedBucketPrimaryAndSecondaryKeyedSource<K1, K2>(
-                  keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey)));
+      SortedBucketPrimaryAndSecondaryKeyedSource<K1, K2> source =
+          new SortedBucketPrimaryAndSecondaryKeyedSource<K1, K2>(
+              keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey);
+      source.lazyKeyGroups = this.lazyKeyGroups;
+      return input.apply(org.apache.beam.sdk.io.Read.from(source));
     }
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -105,6 +105,7 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
   protected SourceSpec sourceSpec;
   protected Long estimatedSizeBytes;
   protected final String metricsKey;
+  protected boolean lazyKeyGroups = false;
 
   public SortedBucketSource(List<BucketedInput<?>> sources) {
     this(sources, TargetParallelism.auto());
@@ -221,7 +222,13 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
     final int totalParallelism = numSplits * effectiveParallelism;
     return IntStream.range(0, numSplits)
         .boxed()
-        .map(splitNum -> createSplitSource(splitNum, totalParallelism, estSplitSize))
+        .map(
+            splitNum -> {
+              SortedBucketSource<KeyType> split =
+                  createSplitSource(splitNum, totalParallelism, estSplitSize);
+              split.lazyKeyGroups = this.lazyKeyGroups;
+              return split;
+            })
         .collect(Collectors.toList());
   }
 
@@ -276,7 +283,7 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
             someArbitraryBucketMetadata,
             comparator(),
             metricsKey,
-            true,
+            !lazyKeyGroups,
             bucketOffsetId,
             effectiveParallelism,
             options),
@@ -419,6 +426,7 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
     protected Keying keying;
     // lazy, internal checks depend on what kind of iteration is requested
     protected transient SourceMetadata<V> sourceMetadata = null; // lazy
+    private int maxPartitionsPerBatch = 0;
 
     private transient Map<ResourceId, KV<String, FileOperations<V>>> inputs;
     private final Map<Integer, KV<String, FileOperations<V>>> fileOperationsEncoding;
@@ -535,6 +543,33 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
       return sampledSource.getValue().getCoder();
     }
 
+    public int getMaxPartitionsPerBatch() {
+      return maxPartitionsPerBatch;
+    }
+
+    public void setMaxPartitionsPerBatch(int max) {
+      this.maxPartitionsPerBatch = max;
+    }
+
+    public boolean needsBatching() {
+      return maxPartitionsPerBatch > 0
+          && getSourceMetadata().mapping.size() > maxPartitionsPerBatch;
+    }
+
+    public List<Set<ResourceId>> getDirectoryBatches() {
+      SourceMetadata<V> sm = getSourceMetadata();
+      List<ResourceId> allDirs = new ArrayList<>(sm.mapping.keySet());
+      if (!needsBatching()) {
+        return Collections.singletonList(new HashSet<>(allDirs));
+      }
+      List<Set<ResourceId>> batches = new ArrayList<>();
+      for (int i = 0; i < allDirs.size(); i += maxPartitionsPerBatch) {
+        batches.add(
+            new HashSet<>(allDirs.subList(i, Math.min(i + maxPartitionsPerBatch, allDirs.size()))));
+      }
+      return batches;
+    }
+
     static CoGbkResultSchema schemaOf(List<BucketedInput<?>> sources) {
       return CoGbkResultSchema.of(
           sources.stream().map(BucketedInput::getTupleTag).collect(Collectors.toList()));
@@ -601,6 +636,11 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
 
     public KeyGroupIterator<V> createIterator(
         int bucketId, int targetParallelism, PipelineOptions options) {
+      return createIterator(bucketId, targetParallelism, options, null);
+    }
+
+    public KeyGroupIterator<V> createIterator(
+        int bucketId, int targetParallelism, PipelineOptions options, Set<ResourceId> dirFilter) {
       SourceMetadata<V> sourceMetadata = getSourceMetadata();
       final Comparator<SortedBucketIO.ComparableKeyBytes> keyComparator =
           (keying == Keying.PRIMARY)
@@ -615,6 +655,7 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
       final List<Iterator<KV<SortedBucketIO.ComparableKeyBytes, V>>> iterators = new ArrayList<>();
       sourceMetadata.mapping.forEach(
           (dir, value) -> {
+            if (dirFilter != null && !dirFilter.contains(dir)) return;
             final int numBuckets = value.metadata.getNumBuckets();
             final int numShards = value.metadata.getNumShards();
             final Function<V, SortedBucketIO.ComparableKeyBytes> keyFn =

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -295,6 +295,7 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
     private final SortedBucketSource<KeyType> currentSource;
     private final MultiSourceKeyGroupReader<KeyType> iter;
     private KV<KeyType, CoGbkResult> next = null;
+    private long recordsEmitted = 0;
 
     MergeBucketsReader(
         MultiSourceKeyGroupReader<KeyType> iter, SortedBucketSource<KeyType> currentSource) {
@@ -317,7 +318,19 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
     @Override
     public boolean advance() throws IOException {
       next = iter.readNext();
+      if (next != null) recordsEmitted++;
       return next != null;
+    }
+
+    @Override
+    public Double getFractionConsumed() {
+      if (next == null && recordsEmitted > 0) return 1.0;
+      // Estimate based on split's estimated byte size and an assumed ~200 bytes per key group.
+      // An imprecise signal is better than null (unknown) for the autoscaler.
+      Long estBytes = currentSource.estimatedSizeBytes;
+      if (estBytes == null || estBytes <= 0) return null;
+      double estRecords = estBytes / 200.0;
+      return Math.min(recordsEmitted / estRecords, 0.99);
     }
 
     @Override

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -652,7 +652,8 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
       final int diskBufferMb = opts.getSortedBucketReadDiskBufferMb();
       FileOperations.setDiskBufferMb(diskBufferMb);
 
-      final List<Iterator<KV<SortedBucketIO.ComparableKeyBytes, V>>> iterators = new ArrayList<>();
+      final List<java.util.concurrent.Callable<List<Iterator<KV<SortedBucketIO.ComparableKeyBytes, V>>>>> tasks =
+          new ArrayList<>();
       sourceMetadata.mapping.forEach(
           (dir, value) -> {
             if (dirFilter != null && !dirFilter.contains(dir)) return;
@@ -662,24 +663,54 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
                 (keying == Keying.PRIMARY)
                     ? value.metadata::primaryComparableKeyBytes
                     : value.metadata::primaryAndSecondaryComparableKeyBytes;
+            final KV<String, FileOperations<V>> inputOps = getInputs().get(dir);
             for (int i = (bucketId % numBuckets); i < numBuckets; i += targetParallelism) {
               for (int j = 0; j < numShards; j++) {
                 ResourceId file =
                     value.fileAssignment.forBucket(BucketShardId.of(i, j), numBuckets, numShards);
-                try {
-                  Iterator<KV<SortedBucketIO.ComparableKeyBytes, V>> iterator =
-                      Iterators.transform(
-                          getInputs().get(dir).getValue().iterator(file),
-                          v -> KV.of(keyFn.apply(v), v));
-                  Iterator<KV<SortedBucketIO.ComparableKeyBytes, V>> out =
-                      (bufferSize > 0) ? new BufferedIterator<>(iterator, bufferSize) : iterator;
-                  iterators.add(out);
-                } catch (Exception e) {
-                  throw new RuntimeException(e);
-                }
+                final int bs = bufferSize;
+                tasks.add(
+                    () -> {
+                      Iterator<KV<SortedBucketIO.ComparableKeyBytes, V>> iterator =
+                          Iterators.transform(
+                              inputOps.getValue().iterator(file),
+                              v -> KV.of(keyFn.apply(v), v));
+                      Iterator<KV<SortedBucketIO.ComparableKeyBytes, V>> out =
+                          (bs > 0) ? new BufferedIterator<>(iterator, bs) : iterator;
+                      return Collections.singletonList(out);
+                    });
               }
             }
           });
+
+      final List<Iterator<KV<SortedBucketIO.ComparableKeyBytes, V>>> iterators = new ArrayList<>();
+      if (tasks.size() <= 1) {
+        for (var task : tasks) {
+          try {
+            iterators.addAll(task.call());
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        }
+      } else {
+        final int parallelism = Math.min(tasks.size(), 32);
+        final java.util.concurrent.ExecutorService pool =
+            java.util.concurrent.Executors.newFixedThreadPool(parallelism);
+        try {
+          final List<java.util.concurrent.Future<List<Iterator<KV<SortedBucketIO.ComparableKeyBytes, V>>>>> futures =
+              pool.invokeAll(tasks);
+          for (var future : futures) {
+            iterators.addAll(future.get());
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new RuntimeException("Interrupted while opening SMB files", e);
+        } catch (java.util.concurrent.ExecutionException e) {
+          throw new RuntimeException("Failed to open SMB file", e.getCause());
+        } finally {
+          pool.shutdown();
+        }
+      }
       return new KeyGroupIterator<>(iterators, keyComparator);
     }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -106,6 +106,9 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
   protected Long estimatedSizeBytes;
   protected final String metricsKey;
   protected boolean lazyKeyGroups = false;
+  // When set, overrides the (bucketOffsetId, effectiveParallelism) bucket assignment.
+  // Used by splitAtFraction to create residual sources for a subset of buckets.
+  protected List<Integer> explicitBucketIds = null;
 
   public SortedBucketSource(List<BucketedInput<?>> sources) {
     this(sources, TargetParallelism.auto());
@@ -158,6 +161,27 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
       int splitNum, int totalParallelism, long estSplitSize);
 
   protected abstract Comparator<SortedBucketIO.ComparableKeyBytes> comparator();
+
+  /** Compute the list of bucket IDs assigned to this source. */
+  List<Integer> getAssignedBuckets() {
+    if (explicitBucketIds != null) return explicitBucketIds;
+    int numBuckets = getOrComputeSourceSpec().greatestNumBuckets;
+    List<Integer> buckets = new ArrayList<>();
+    for (int i = bucketOffsetId; i < numBuckets; i += effectiveParallelism) {
+      buckets.add(i);
+    }
+    return buckets;
+  }
+
+  /** Create a copy of this source for a specific set of bucket IDs. */
+  SortedBucketSource<KeyType> createSourceForBuckets(List<Integer> bucketIds, long estSize) {
+    // Use bucket 0 as dummy offset — explicitBucketIds overrides the assignment
+    SortedBucketSource<KeyType> copy =
+        createSplitSource(0, effectiveParallelism, estSize);
+    copy.lazyKeyGroups = this.lazyKeyGroups;
+    copy.explicitBucketIds = bucketIds;
+    return copy;
+  }
 
   private static String getDefaultMetricsKey() {
     return "SortedBucketSource{" + metricsId.getAndAdd(1) + "}";
@@ -272,39 +296,109 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
   @Override
   public BoundedReader<KV<KeyType, CoGbkResult>> createReader(final PipelineOptions options)
       throws IOException {
-    // get any arbitrary metadata to be able to rehash keys into buckets
-    BucketMetadata<?, ?, ?> someArbitraryBucketMetadata =
-        sources.get(0).getSourceMetadata().mapping.values().stream().findAny().get().metadata;
-    return new MergeBucketsReader<>(
-        new MultiSourceKeyGroupReader<KeyType>(
-            sources,
-            toKeyFn(),
-            coGbkResultSchema(),
-            someArbitraryBucketMetadata,
-            comparator(),
-            metricsKey,
-            !lazyKeyGroups,
-            bucketOffsetId,
-            effectiveParallelism,
-            options),
-        this);
+    return new MergeBucketsReader<>(this, options);
   }
 
-  /** Merge key-value groups in matching buckets. */
+  /**
+   * Merge key-value groups in matching buckets. Processes buckets sequentially (one at a time)
+   * to support dynamic work rebalancing via {@link #splitAtFraction}.
+   */
   static class MergeBucketsReader<KeyType> extends BoundedReader<KV<KeyType, CoGbkResult>> {
-    private final SortedBucketSource<KeyType> currentSource;
-    private final MultiSourceKeyGroupReader<KeyType> iter;
-    private KV<KeyType, CoGbkResult> next = null;
-    private long recordsEmitted = 0;
+    private final SortedBucketSource<KeyType> originalSource;
+    private final PipelineOptions options;
 
-    MergeBucketsReader(
-        MultiSourceKeyGroupReader<KeyType> iter, SortedBucketSource<KeyType> currentSource) {
-      this.currentSource = currentSource;
-      this.iter = iter;
+    // Synchronized state for splitAtFraction
+    private final Object splitLock = new Object();
+    private List<Integer> assignedBuckets;
+    private int currentBucketIdx = 0;
+
+    private MultiSourceKeyGroupReader<KeyType> currentReader;
+    private KV<KeyType, CoGbkResult> next = null;
+    private boolean started = false;
+
+    MergeBucketsReader(SortedBucketSource<KeyType> source, PipelineOptions options) {
+      this.originalSource = source;
+      this.options = options;
+      this.assignedBuckets = new ArrayList<>(source.getAssignedBuckets());
+      // Sequential bucket processing only works when all sources have the same bucket count.
+      // With mixed counts, fall back to processing all buckets in one merge-sort.
+      SourceSpec spec = source.getOrComputeSourceSpec();
+      this.sequentialMode = (spec.leastNumBuckets == spec.greatestNumBuckets);
+    }
+
+    private final boolean sequentialMode;
+
+    private MultiSourceKeyGroupReader<KeyType> createReaderForBucket(int bucketId) {
+      BucketMetadata<?, ?, ?> someArbitraryBucketMetadata =
+          originalSource.sources.get(0).getSourceMetadata().mapping.values().stream()
+              .findAny()
+              .get()
+              .metadata;
+      int numBuckets = originalSource.getOrComputeSourceSpec().greatestNumBuckets;
+      return new MultiSourceKeyGroupReader<KeyType>(
+          originalSource.sources,
+          originalSource.toKeyFn(),
+          originalSource.coGbkResultSchema(),
+          someArbitraryBucketMetadata,
+          originalSource.comparator(),
+          originalSource.metricsKey,
+          !originalSource.lazyKeyGroups,
+          bucketId,
+          numBuckets,
+          options);
+    }
+
+    private MultiSourceKeyGroupReader<KeyType> createReaderForAllBuckets() {
+      BucketMetadata<?, ?, ?> someArbitraryBucketMetadata =
+          originalSource.sources.get(0).getSourceMetadata().mapping.values().stream()
+              .findAny()
+              .get()
+              .metadata;
+      return new MultiSourceKeyGroupReader<KeyType>(
+          originalSource.sources,
+          originalSource.toKeyFn(),
+          originalSource.coGbkResultSchema(),
+          someArbitraryBucketMetadata,
+          originalSource.comparator(),
+          originalSource.metricsKey,
+          !originalSource.lazyKeyGroups,
+          originalSource.bucketOffsetId,
+          originalSource.effectiveParallelism,
+          options);
+    }
+
+    private boolean advanceToNextBucket() {
+      synchronized (splitLock) {
+        currentBucketIdx++;
+        if (currentBucketIdx >= assignedBuckets.size()) {
+          currentReader = null;
+          return false;
+        }
+      }
+      int bucketId;
+      synchronized (splitLock) {
+        bucketId = assignedBuckets.get(currentBucketIdx);
+      }
+      currentReader = createReaderForBucket(bucketId);
+      return true;
     }
 
     @Override
     public boolean start() throws IOException {
+      started = true;
+      if (sequentialMode) {
+        if (assignedBuckets.isEmpty()) return false;
+        synchronized (splitLock) {
+          currentBucketIdx = 0;
+        }
+        int bucketId;
+        synchronized (splitLock) {
+          bucketId = assignedBuckets.get(0);
+        }
+        currentReader = createReaderForBucket(bucketId);
+      } else {
+        currentReader = createReaderForAllBuckets();
+      }
       return advance();
     }
 
@@ -314,23 +408,64 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
       return next;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public boolean advance() throws IOException {
-      next = iter.readNext();
-      if (next != null) recordsEmitted++;
-      return next != null;
+      if (sequentialMode) {
+        while (true) {
+          if (currentReader == null) return false;
+          next = currentReader.readNext();
+          if (next != null) return true;
+          if (!advanceToNextBucket()) return false;
+        }
+      } else {
+        if (currentReader == null) return false;
+        next = currentReader.readNext();
+        return next != null;
+      }
     }
 
     @Override
     public Double getFractionConsumed() {
-      if (next == null && recordsEmitted > 0) return 1.0;
-      // Estimate based on split's estimated byte size and an assumed ~200 bytes per key group.
-      // An imprecise signal is better than null (unknown) for the autoscaler.
-      Long estBytes = currentSource.estimatedSizeBytes;
-      if (estBytes == null || estBytes <= 0) return null;
-      double estRecords = estBytes / 200.0;
-      return Math.min(recordsEmitted / estRecords, 0.99);
+      if (!sequentialMode) return null;
+      synchronized (splitLock) {
+        if (assignedBuckets.isEmpty()) return 1.0;
+        if (!started) return 0.0;
+        return (double) currentBucketIdx / assignedBuckets.size();
+      }
+    }
+
+    @Override
+    public BoundedSource<KV<KeyType, CoGbkResult>> splitAtFraction(double fraction) {
+      synchronized (splitLock) {
+        // Only support dynamic splitting when all sources have the same bucket count.
+        // Mixed bucket counts require rehashing across logical buckets, which makes
+        // sequential per-bucket processing produce duplicate or missing records.
+        SourceSpec spec = originalSource.getOrComputeSourceSpec();
+        if (spec.leastNumBuckets != spec.greatestNumBuckets) return null;
+
+        int remaining = assignedBuckets.size() - currentBucketIdx - 1;
+        if (remaining <= 0) return null;
+
+        int splitPoint = currentBucketIdx + 1 + (int) Math.floor(remaining * fraction);
+        if (splitPoint <= currentBucketIdx) return null;
+        if (splitPoint >= assignedBuckets.size()) return null;
+
+        // Residual: buckets from splitPoint onwards
+        List<Integer> residualBuckets =
+            new ArrayList<>(assignedBuckets.subList(splitPoint, assignedBuckets.size()));
+        // Primary: keep buckets up to splitPoint
+        assignedBuckets = new ArrayList<>(assignedBuckets.subList(0, splitPoint));
+
+        long estResidualSize =
+            originalSource.estimatedSizeBytes != null
+                ? (long)
+                    (originalSource.estimatedSizeBytes
+                        * ((double) residualBuckets.size()
+                            / (residualBuckets.size() + assignedBuckets.size())))
+                : 0L;
+
+        return originalSource.createSourceForBuckets(residualBuckets, estResidualSize);
+      }
     }
 
     @Override
@@ -338,7 +473,7 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
 
     @Override
     public BoundedSource<KV<KeyType, CoGbkResult>> getCurrentSource() {
-      return currentSource;
+      return originalSource;
     }
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.smb;
 import java.io.IOException;
 import java.io.Serializable;
 import java.text.DecimalFormat;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -226,12 +228,13 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
         if (bucketMetadata == null) {
           try {
             bucketMetadata =
-                newBucketMetadataFn.createMetadata(bucket.totalNumBuckets, 1, hashType);
+                newBucketMetadataFn.createMetadata(
+                    bucket.totalNumBuckets, bucket.numShards, hashType);
           } catch (Exception e) {
             throw new RuntimeException(e);
           }
         }
-        writtenBuckets.put(BucketShardId.of(bucket.bucketId, 0), bucket.destination);
+        writtenBuckets.put(BucketShardId.of(bucket.bucketId, bucket.shardId), bucket.destination);
       }
 
       RenameBuckets.moveFiles(
@@ -277,11 +280,24 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
   public static class MergedBucket implements Serializable {
     final ResourceId destination;
     final int bucketId;
+    final int shardId;
+    final int numShards;
     final int totalNumBuckets;
 
     MergedBucket(Integer bucketId, ResourceId destination, Integer totalNumBuckets) {
+      this(bucketId, 0, 1, destination, totalNumBuckets);
+    }
+
+    MergedBucket(
+        Integer bucketId,
+        Integer shardId,
+        Integer numShards,
+        ResourceId destination,
+        Integer totalNumBuckets) {
       this.destination = destination;
       this.bucketId = bucketId;
+      this.shardId = shardId;
+      this.numShards = numShards;
       this.totalNumBuckets = totalNumBuckets;
     }
 
@@ -293,12 +309,14 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
       MergedBucket that = (MergedBucket) o;
       return Objects.equals(destination, that.destination)
           && Objects.equals(bucketId, that.bucketId)
+          && shardId == that.shardId
+          && numShards == that.numShards
           && Objects.equals(totalNumBuckets, that.totalNumBuckets);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(destination, bucketId, totalNumBuckets);
+      return Objects.hash(destination, bucketId, shardId, numShards, totalNumBuckets);
     }
   }
 
@@ -453,56 +471,85 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
       int bucketId = e.bucketOffsetId;
       int effectiveParallelism = e.effectiveParallelism;
 
-      ResourceId dst =
-          fileAssignment.forBucket(BucketShardId.of(bucketId, 0), effectiveParallelism, 1);
-      OutputCollector<FinalValueT> outputCollector;
-      final Counter recordsWritten =
-          Metrics.counter(metricsPrefix, metricsPrefix + "-RecordsWritten");
-      try {
-        outputCollector = new OutputCollector<>(fileOperations.createWriter(dst), recordsWritten);
-      } catch (IOException err) {
-        throw new RuntimeException("Failed to create file writer for transformed output", err);
-      }
-
       // get any arbitrary metadata to be able to rehash keys into buckets
       BucketMetadata<?, ?, ?> someArbitraryBucketMetadata =
           sources.get(0).getSourceMetadata().mapping.values().stream().findAny().get().metadata;
-      final MultiSourceKeyGroupReader<FinalKeyT> iter =
-          new MultiSourceKeyGroupReader<FinalKeyT>(
-              sources,
-              keyFn,
-              coGbkResultSchema(),
-              someArbitraryBucketMetadata,
-              keyComparator,
-              metricsPrefix,
-              false,
-              bucketId,
-              effectiveParallelism,
-              context.getPipelineOptions());
-      while (true) {
-        try {
-          KV<FinalKeyT, CoGbkResult> mergedKeyGroup = iter.readNext();
-          if (mergedKeyGroup == null) break;
-          outputTransform(mergedKeyGroup, context, outputCollector, window);
 
-          // exhaust iterators if necessary before moving on to the next key group:
-          // for example, if not every element was needed in the transformFn
-          sources.forEach(
-              source -> {
-                final Iterable<?> maybeUnfinishedIt =
-                    mergedKeyGroup.getValue().getAll(source.getTupleTag());
-                if (SortedBucketSource.TraversableOnceIterable.class.isAssignableFrom(
-                    maybeUnfinishedIt.getClass())) {
-                  ((SortedBucketSource.TraversableOnceIterable<?>) maybeUnfinishedIt)
-                      .ensureExhausted();
-                }
-              });
-        } catch (Exception ex) {
-          throw new RuntimeException("Failed to write merged key group", ex);
+      // Check if any source needs directory batching
+      SortedBucketSource.BucketedInput<?> batchedSource =
+          sources.stream()
+              .filter(SortedBucketSource.BucketedInput::needsBatching)
+              .findFirst()
+              .orElse(null);
+
+      List<Map<TupleTag<?>, Set<ResourceId>>> batchFilters;
+      if (batchedSource != null) {
+        TupleTag<?> tag = batchedSource.getTupleTag();
+        batchFilters = new java.util.ArrayList<>();
+        for (Set<ResourceId> batch : batchedSource.getDirectoryBatches()) {
+          Map<TupleTag<?>, Set<ResourceId>> filter = new HashMap<>();
+          filter.put(tag, batch);
+          batchFilters.add(filter);
         }
+      } else {
+        batchFilters = Collections.singletonList(null);
       }
-      outputCollector.onComplete();
-      out.output(new MergedBucket(bucketId, dst, effectiveParallelism));
+
+      int numShards = batchFilters.size();
+      final Counter recordsWritten =
+          Metrics.counter(metricsPrefix, metricsPrefix + "-RecordsWritten");
+
+      for (int shardIdx = 0; shardIdx < numShards; shardIdx++) {
+        Map<TupleTag<?>, Set<ResourceId>> dirFilter = batchFilters.get(shardIdx);
+
+        ResourceId dst =
+            fileAssignment.forBucket(
+                BucketShardId.of(bucketId, shardIdx), effectiveParallelism, numShards);
+        OutputCollector<FinalValueT> outputCollector;
+        try {
+          outputCollector = new OutputCollector<>(fileOperations.createWriter(dst), recordsWritten);
+        } catch (IOException err) {
+          throw new RuntimeException("Failed to create file writer for transformed output", err);
+        }
+
+        final MultiSourceKeyGroupReader<FinalKeyT> iter =
+            new MultiSourceKeyGroupReader<FinalKeyT>(
+                sources,
+                keyFn,
+                coGbkResultSchema(),
+                someArbitraryBucketMetadata,
+                keyComparator,
+                metricsPrefix,
+                false,
+                bucketId,
+                effectiveParallelism,
+                context.getPipelineOptions(),
+                dirFilter);
+        while (true) {
+          try {
+            KV<FinalKeyT, CoGbkResult> mergedKeyGroup = iter.readNext();
+            if (mergedKeyGroup == null) break;
+            outputTransform(mergedKeyGroup, context, outputCollector, window);
+
+            // exhaust iterators if necessary before moving on to the next key group:
+            // for example, if not every element was needed in the transformFn
+            sources.forEach(
+                source -> {
+                  final Iterable<?> maybeUnfinishedIt =
+                      mergedKeyGroup.getValue().getAll(source.getTupleTag());
+                  if (SortedBucketSource.TraversableOnceIterable.class.isAssignableFrom(
+                      maybeUnfinishedIt.getClass())) {
+                    ((SortedBucketSource.TraversableOnceIterable<?>) maybeUnfinishedIt)
+                        .ensureExhausted();
+                  }
+                });
+          } catch (Exception ex) {
+            throw new RuntimeException("Failed to write merged key group", ex);
+          }
+        }
+        outputCollector.onComplete();
+        out.output(new MergedBucket(bucketId, shardIdx, numShards, dst, effectiveParallelism));
+      }
     }
   }
 

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
@@ -282,7 +282,17 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
     keyClass: Class[K],
     a: SortedBucketIO.Read[A],
     b: SortedBucketIO.Read[B],
-    targetParallelism: TargetParallelism = TargetParallelism.auto()
+    targetParallelism: TargetParallelism,
+    lazyKeyGroups: Boolean
+  ): SCollection[(K, (Iterable[A], Iterable[B]))] =
+    SMBMultiJoin(self).sortMergeCoGroup(keyClass, a, b, targetParallelism, lazyKeyGroups)
+
+  @experimental
+  def sortMergeCoGroup[K: Coder, A: Coder, B: Coder](
+    keyClass: Class[K],
+    a: SortedBucketIO.Read[A],
+    b: SortedBucketIO.Read[B],
+    targetParallelism: TargetParallelism
   ): SCollection[(K, (Iterable[A], Iterable[B]))] =
     SMBMultiJoin(self).sortMergeCoGroup(keyClass, a, b, targetParallelism)
 
@@ -357,6 +367,17 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
    *   the desired parallelism of the job. See
    *   [[org.apache.beam.sdk.extensions.smb.TargetParallelism]] for more information.
    */
+  @experimental
+  def sortMergeCoGroup[K: Coder, A: Coder, B: Coder, C: Coder](
+    keyClass: Class[K],
+    a: SortedBucketIO.Read[A],
+    b: SortedBucketIO.Read[B],
+    c: SortedBucketIO.Read[C],
+    targetParallelism: TargetParallelism,
+    lazyKeyGroups: Boolean
+  ): SCollection[(K, (Iterable[A], Iterable[B], Iterable[C]))] =
+    SMBMultiJoin(self).sortMergeCoGroup(keyClass, a, b, c, targetParallelism, lazyKeyGroups)
+
   @experimental
   def sortMergeCoGroup[K: Coder, A: Coder, B: Coder, C: Coder](
     keyClass: Class[K],

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/util/SMBMultiJoin.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/util/SMBMultiJoin.scala
@@ -29,7 +29,7 @@ import org.typelevel.scalaccompat.annotation.nowarn
 
 import scala.jdk.CollectionConverters._
 final class SMBMultiJoin(private val self: ScioContext) {
-	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], targetParallelism: TargetParallelism): SCollection[(KEY, (Iterable[A], Iterable[B]))] = self.requireNotClosed {
+	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], targetParallelism: TargetParallelism, lazyKeyGroups: Boolean): SCollection[(KEY, (Iterable[A], Iterable[B]))] = self.requireNotClosed {
 		val tfName = self.tfName
 		val keyed = if (self.isTest) {
 			testCoGroup[KEY](a, b)
@@ -38,6 +38,7 @@ final class SMBMultiJoin(private val self: ScioContext) {
 				.read(keyClass)
 				.of(a, b)
 				.withTargetParallelism(targetParallelism)
+				.withLazyKeyGroups(lazyKeyGroups)
 			self.wrap(self.pipeline.apply(s"SMB CoGroupByKey@$tfName", transform))
 		}
 		val tupleTagA = a.getTupleTag
@@ -56,11 +57,15 @@ final class SMBMultiJoin(private val self: ScioContext) {
 			}
 	}
 
-	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B]): SCollection[(KEY, (Iterable[A], Iterable[B]))] = {
-		sortMergeCoGroup(keyClass, a, b, TargetParallelism.auto())
+	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], targetParallelism: TargetParallelism): SCollection[(KEY, (Iterable[A], Iterable[B]))] = {
+		sortMergeCoGroup(keyClass, a, b, targetParallelism, false)
 	}
 
-	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder, C: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], c: SortedBucketIO.Read[C], targetParallelism: TargetParallelism): SCollection[(KEY, (Iterable[A], Iterable[B], Iterable[C]))] = self.requireNotClosed {
+	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B]): SCollection[(KEY, (Iterable[A], Iterable[B]))] = {
+		sortMergeCoGroup(keyClass, a, b, TargetParallelism.auto(), false)
+	}
+
+	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder, C: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], c: SortedBucketIO.Read[C], targetParallelism: TargetParallelism, lazyKeyGroups: Boolean): SCollection[(KEY, (Iterable[A], Iterable[B], Iterable[C]))] = self.requireNotClosed {
 		val tfName = self.tfName
 		val keyed = if (self.isTest) {
 			testCoGroup[KEY](a, b, c)
@@ -69,6 +74,7 @@ final class SMBMultiJoin(private val self: ScioContext) {
 				.read(keyClass)
 				.of(a, b, c)
 				.withTargetParallelism(targetParallelism)
+				.withLazyKeyGroups(lazyKeyGroups)
 			self.wrap(self.pipeline.apply(s"SMB CoGroupByKey@$tfName", transform))
 		}
 		val tupleTagA = a.getTupleTag
@@ -89,8 +95,12 @@ final class SMBMultiJoin(private val self: ScioContext) {
 			}
 	}
 
+	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder, C: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], c: SortedBucketIO.Read[C], targetParallelism: TargetParallelism): SCollection[(KEY, (Iterable[A], Iterable[B], Iterable[C]))] = {
+		sortMergeCoGroup(keyClass, a, b, c, targetParallelism, false)
+	}
+
 	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder, C: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], c: SortedBucketIO.Read[C]): SCollection[(KEY, (Iterable[A], Iterable[B], Iterable[C]))] = {
-		sortMergeCoGroup(keyClass, a, b, c, TargetParallelism.auto())
+		sortMergeCoGroup(keyClass, a, b, c, TargetParallelism.auto(), false)
 	}
 
 	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder, C: Coder, D: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], c: SortedBucketIO.Read[C], d: SortedBucketIO.Read[D], targetParallelism: TargetParallelism): SCollection[(KEY, (Iterable[A], Iterable[B], Iterable[C], Iterable[D]))] = self.requireNotClosed {

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIO.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIO.scala
@@ -64,7 +64,8 @@ object ParquetTypeSortedBucketIO {
     filenameSuffix: String = DefaultSuffix,
     filterPredicate: FilterPredicate = null,
     predicate: Predicate[T] = null,
-    configuration: Configuration = new Configuration()
+    configuration: Configuration = new Configuration(),
+    maxPartitionsPerBatch: Int = 0
   ) extends SortedBucketIO.Read[T] {
     def from(inputDirectories: String*): Read[T] =
       this.copy(inputDirectories = inputDirectories)
@@ -81,6 +82,9 @@ object ParquetTypeSortedBucketIO {
     def withConfiguration(configuration: Configuration): Read[T] =
       this.copy(configuration = configuration)
 
+    def withMaxPartitionsPerBatch(max: Int): Read[T] =
+      this.copy(maxPartitionsPerBatch = max)
+
     def getInputDirectories: ImmutableList[String] =
       ImmutableList.copyOf(inputDirectories.asJava: java.lang.Iterable[String])
     def getFilenameSuffix: String = filenameSuffix
@@ -90,7 +94,7 @@ object ParquetTypeSortedBucketIO {
     override def toBucketedInput(
       keying: SortedBucketSource.Keying
     ): SortedBucketSource.BucketedInput[T] = {
-      BucketedInput.of(
+      val input = BucketedInput.of(
         keying,
         getTupleTag,
         inputDirectories.asJava,
@@ -98,6 +102,8 @@ object ParquetTypeSortedBucketIO {
         getFileOperations,
         predicate
       )
+      if (maxPartitionsPerBatch > 0) input.setMaxPartitionsPerBatch(maxPartitionsPerBatch)
+      input
     }
 
     def getFileOperations: FileOperations[T] =


### PR DESCRIPTION
Has scaling issues, either:

* --autoscalingAlgorithm=NONE  + manually set  --numWorkers=200
* Use dataflowRunnerV2

Contains lots of optimization against OOM errors and bad scaling, that might not be needed with ⬆️ fixes.

Test runs [here](https://ghe.spotify.net/key-metrics/key-metrics-pipelines/pull/1272).