### PR TITLE
Add lazy key groups for CoGroup and directory batching for Transform

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/MultiSourceKeyGroupReader.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/MultiSourceKeyGroupReader.java
@@ -21,10 +21,12 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.beam.sdk.extensions.smb.SortedBucketIO.ComparableKeyBytes;
+import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.Metrics;
@@ -79,6 +81,32 @@ public class MultiSourceKeyGroupReader<KeyType> {
       int bucketId,
       int effectiveParallelism,
       PipelineOptions options) {
+    this(
+        sources,
+        keyFn,
+        resultSchema,
+        someArbitraryBucketMetadata,
+        keyComparator,
+        metricsPrefix,
+        materializeKeyGroup,
+        bucketId,
+        effectiveParallelism,
+        options,
+        null);
+  }
+
+  public MultiSourceKeyGroupReader(
+      List<SortedBucketSource.BucketedInput<?>> sources,
+      Function<ComparableKeyBytes, KeyType> keyFn,
+      CoGbkResultSchema resultSchema,
+      BucketMetadata<?, ?, ?> someArbitraryBucketMetadata,
+      Comparator<ComparableKeyBytes> keyComparator,
+      String metricsPrefix,
+      boolean materializeKeyGroup,
+      int bucketId,
+      int effectiveParallelism,
+      PipelineOptions options,
+      Map<TupleTag<?>, Set<ResourceId>> directoryFilters) {
     this.keyFn = keyFn;
     this.keyGroupSize = Metrics.distribution(metricsPrefix, metricsPrefix + "-KeyGroupSize");
     this.predicateFilteredRecordsCounts =
@@ -97,7 +125,12 @@ public class MultiSourceKeyGroupReader<KeyType> {
     this.resultSchema = resultSchema;
     this.bucketedInputs =
         sources.stream()
-            .map(src -> new BucketIterator<>(src, bucketId, effectiveParallelism, options))
+            .map(
+                src -> {
+                  Set<ResourceId> filter =
+                      directoryFilters != null ? directoryFilters.get(src.tupleTag) : null;
+                  return new BucketIterator<>(src, bucketId, effectiveParallelism, options, filter);
+                })
             .collect(Collectors.toList());
     // this only operates on the primary key
     this.keyGroupFilter =
@@ -254,9 +287,18 @@ public class MultiSourceKeyGroupReader<KeyType> {
         int bucketId,
         int parallelism,
         PipelineOptions options) {
+      this(source, bucketId, parallelism, options, null);
+    }
+
+    BucketIterator(
+        SortedBucketSource.BucketedInput<V> source,
+        int bucketId,
+        int parallelism,
+        PipelineOptions options,
+        Set<ResourceId> directoryFilter) {
       this.predicate = source.getPredicate();
       this.tupleTag = source.getTupleTag();
-      this.iter = source.createIterator(bucketId, parallelism, options);
+      this.iter = source.createIterator(bucketId, parallelism, options, directoryFilter);
 
       int numBuckets = source.getSourceMetadata().leastNumBuckets();
       // The canonical # buckets for this source. If # buckets >= the parallelism of the job,

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -148,16 +148,27 @@ public class SortedBucketIO {
     private final List<BucketedInput<?>> inputs;
     private final TargetParallelism targetParallelism;
     private final String metricsKey;
+    private final boolean lazyKeyGroups;
 
     private CoGbk(
         Class<K> keyClass,
         List<BucketedInput<?>> inputs,
         TargetParallelism targetParallelism,
         String metricsKey) {
+      this(keyClass, inputs, targetParallelism, metricsKey, false);
+    }
+
+    private CoGbk(
+        Class<K> keyClass,
+        List<BucketedInput<?>> inputs,
+        TargetParallelism targetParallelism,
+        String metricsKey,
+        boolean lazyKeyGroups) {
       this.keyClass = keyClass;
       this.inputs = inputs;
       this.targetParallelism = targetParallelism;
       this.metricsKey = metricsKey;
+      this.lazyKeyGroups = lazyKeyGroups;
     }
 
     /**
@@ -171,15 +182,24 @@ public class SortedBucketIO {
               .add(read.toBucketedInput(SortedBucketSource.Keying.PRIMARY))
               .build();
       validateInputNameUniqueness(newReads);
-      return new CoGbk<>(keyClass, newReads, targetParallelism, metricsKey);
+      return new CoGbk<>(keyClass, newReads, targetParallelism, metricsKey, lazyKeyGroups);
     }
 
     public CoGbk<K> withTargetParallelism(TargetParallelism targetParallelism) {
-      return new CoGbk<>(keyClass, inputs, targetParallelism, metricsKey);
+      return new CoGbk<>(keyClass, inputs, targetParallelism, metricsKey, lazyKeyGroups);
     }
 
     public CoGbk<K> withMetricsKey(String metricsKey) {
-      return new CoGbk<>(keyClass, inputs, targetParallelism, metricsKey);
+      return new CoGbk<>(keyClass, inputs, targetParallelism, metricsKey, lazyKeyGroups);
+    }
+
+    /**
+     * When enabled, key group iterables in the CoGbkResult are lazily evaluated instead of eagerly
+     * materialized into Lists. This reduces memory usage for large key groups but means each
+     * Iterable can only be traversed once.
+     */
+    public CoGbk<K> withLazyKeyGroups(boolean lazy) {
+      return new CoGbk<>(keyClass, inputs, targetParallelism, metricsKey, lazy);
     }
 
     public <V> CoGbkTransform<K, V> transform(TransformOutput<K, Void, V> transform) {
@@ -188,10 +208,10 @@ public class SortedBucketIO {
 
     @Override
     public PCollection<KV<K, CoGbkResult>> expand(PBegin input) {
-      return input.apply(
-          org.apache.beam.sdk.io.Read.from(
-              new SortedBucketPrimaryKeyedSource<>(
-                  keyClass, inputs, targetParallelism, metricsKey)));
+      SortedBucketPrimaryKeyedSource<K> source =
+          new SortedBucketPrimaryKeyedSource<>(keyClass, inputs, targetParallelism, metricsKey);
+      source.lazyKeyGroups = this.lazyKeyGroups;
+      return input.apply(org.apache.beam.sdk.io.Read.from(source));
     }
   }
 
@@ -207,6 +227,7 @@ public class SortedBucketIO {
     private final List<BucketedInput<?>> inputs;
     private final TargetParallelism targetParallelism;
     private final String metricsKey;
+    private final boolean lazyKeyGroups;
 
     private CoGbkWithSecondary(
         Class<K1> keyClassPrimary,
@@ -214,11 +235,22 @@ public class SortedBucketIO {
         List<BucketedInput<?>> inputs,
         TargetParallelism targetParallelism,
         String metricsKey) {
+      this(keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey, false);
+    }
+
+    private CoGbkWithSecondary(
+        Class<K1> keyClassPrimary,
+        Class<K2> keyClassSecondary,
+        List<BucketedInput<?>> inputs,
+        TargetParallelism targetParallelism,
+        String metricsKey,
+        boolean lazyKeyGroups) {
       this.keyClassPrimary = keyClassPrimary;
       this.keyClassSecondary = keyClassSecondary;
       this.inputs = inputs;
       this.targetParallelism = targetParallelism;
       this.metricsKey = metricsKey;
+      this.lazyKeyGroups = lazyKeyGroups;
     }
 
     /**
@@ -233,17 +265,27 @@ public class SortedBucketIO {
               .build();
       validateInputNameUniqueness(newReads);
       return new CoGbkWithSecondary<>(
-          keyClassPrimary, keyClassSecondary, newReads, targetParallelism, metricsKey);
+          keyClassPrimary,
+          keyClassSecondary,
+          newReads,
+          targetParallelism,
+          metricsKey,
+          lazyKeyGroups);
     }
 
     public CoGbkWithSecondary<K1, K2> withTargetParallelism(TargetParallelism targetParallelism) {
       return new CoGbkWithSecondary<>(
-          keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey);
+          keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey, lazyKeyGroups);
     }
 
     public CoGbkWithSecondary<K1, K2> withMetricsKey(String metricsKey) {
       return new CoGbkWithSecondary<>(
-          keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey);
+          keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey, lazyKeyGroups);
+    }
+
+    public CoGbkWithSecondary<K1, K2> withLazyKeyGroups(boolean lazy) {
+      return new CoGbkWithSecondary<>(
+          keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey, lazy);
     }
 
     public <V> CoGbkTransformWithSecondary<K1, K2, V> transform(
@@ -254,10 +296,11 @@ public class SortedBucketIO {
 
     @Override
     public PCollection<KV<KV<K1, K2>, CoGbkResult>> expand(PBegin input) {
-      return input.apply(
-          org.apache.beam.sdk.io.Read.from(
-              new SortedBucketPrimaryAndSecondaryKeyedSource<K1, K2>(
-                  keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey)));
+      SortedBucketPrimaryAndSecondaryKeyedSource<K1, K2> source =
+          new SortedBucketPrimaryAndSecondaryKeyedSource<K1, K2>(
+              keyClassPrimary, keyClassSecondary, inputs, targetParallelism, metricsKey);
+      source.lazyKeyGroups = this.lazyKeyGroups;
+      return input.apply(org.apache.beam.sdk.io.Read.from(source));
     }
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -105,6 +105,7 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
   protected SourceSpec sourceSpec;
   protected Long estimatedSizeBytes;
   protected final String metricsKey;
+  protected boolean lazyKeyGroups = false;
 
   public SortedBucketSource(List<BucketedInput<?>> sources) {
     this(sources, TargetParallelism.auto());
@@ -221,7 +222,13 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
     final int totalParallelism = numSplits * effectiveParallelism;
     return IntStream.range(0, numSplits)
         .boxed()
-        .map(splitNum -> createSplitSource(splitNum, totalParallelism, estSplitSize))
+        .map(
+            splitNum -> {
+              SortedBucketSource<KeyType> split =
+                  createSplitSource(splitNum, totalParallelism, estSplitSize);
+              split.lazyKeyGroups = this.lazyKeyGroups;
+              return split;
+            })
         .collect(Collectors.toList());
   }
 
@@ -276,7 +283,7 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
             someArbitraryBucketMetadata,
             comparator(),
             metricsKey,
-            true,
+            !lazyKeyGroups,
             bucketOffsetId,
             effectiveParallelism,
             options),
@@ -419,6 +426,7 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
     protected Keying keying;
     // lazy, internal checks depend on what kind of iteration is requested
     protected transient SourceMetadata<V> sourceMetadata = null; // lazy
+    private int maxPartitionsPerBatch = 0;
 
     private transient Map<ResourceId, KV<String, FileOperations<V>>> inputs;
     private final Map<Integer, KV<String, FileOperations<V>>> fileOperationsEncoding;
@@ -535,6 +543,33 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
       return sampledSource.getValue().getCoder();
     }
 
+    public int getMaxPartitionsPerBatch() {
+      return maxPartitionsPerBatch;
+    }
+
+    public void setMaxPartitionsPerBatch(int max) {
+      this.maxPartitionsPerBatch = max;
+    }
+
+    public boolean needsBatching() {
+      return maxPartitionsPerBatch > 0
+          && getSourceMetadata().mapping.size() > maxPartitionsPerBatch;
+    }
+
+    public List<Set<ResourceId>> getDirectoryBatches() {
+      SourceMetadata<V> sm = getSourceMetadata();
+      List<ResourceId> allDirs = new ArrayList<>(sm.mapping.keySet());
+      if (!needsBatching()) {
+        return Collections.singletonList(new HashSet<>(allDirs));
+      }
+      List<Set<ResourceId>> batches = new ArrayList<>();
+      for (int i = 0; i < allDirs.size(); i += maxPartitionsPerBatch) {
+        batches.add(
+            new HashSet<>(allDirs.subList(i, Math.min(i + maxPartitionsPerBatch, allDirs.size()))));
+      }
+      return batches;
+    }
+
     static CoGbkResultSchema schemaOf(List<BucketedInput<?>> sources) {
       return CoGbkResultSchema.of(
           sources.stream().map(BucketedInput::getTupleTag).collect(Collectors.toList()));
@@ -601,6 +636,11 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
 
     public KeyGroupIterator<V> createIterator(
         int bucketId, int targetParallelism, PipelineOptions options) {
+      return createIterator(bucketId, targetParallelism, options, null);
+    }
+
+    public KeyGroupIterator<V> createIterator(
+        int bucketId, int targetParallelism, PipelineOptions options, Set<ResourceId> dirFilter) {
       SourceMetadata<V> sourceMetadata = getSourceMetadata();
       final Comparator<SortedBucketIO.ComparableKeyBytes> keyComparator =
           (keying == Keying.PRIMARY)
@@ -615,6 +655,7 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
       final List<Iterator<KV<SortedBucketIO.ComparableKeyBytes, V>>> iterators = new ArrayList<>();
       sourceMetadata.mapping.forEach(
           (dir, value) -> {
+            if (dirFilter != null && !dirFilter.contains(dir)) return;
             final int numBuckets = value.metadata.getNumBuckets();
             final int numShards = value.metadata.getNumShards();
             final Function<V, SortedBucketIO.ComparableKeyBytes> keyFn =

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.smb;
 import java.io.IOException;
 import java.io.Serializable;
 import java.text.DecimalFormat;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -226,12 +228,13 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
         if (bucketMetadata == null) {
           try {
             bucketMetadata =
-                newBucketMetadataFn.createMetadata(bucket.totalNumBuckets, 1, hashType);
+                newBucketMetadataFn.createMetadata(
+                    bucket.totalNumBuckets, bucket.numShards, hashType);
           } catch (Exception e) {
             throw new RuntimeException(e);
           }
         }
-        writtenBuckets.put(BucketShardId.of(bucket.bucketId, 0), bucket.destination);
+        writtenBuckets.put(BucketShardId.of(bucket.bucketId, bucket.shardId), bucket.destination);
       }
 
       RenameBuckets.moveFiles(
@@ -277,11 +280,24 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
   public static class MergedBucket implements Serializable {
     final ResourceId destination;
     final int bucketId;
+    final int shardId;
+    final int numShards;
     final int totalNumBuckets;
 
     MergedBucket(Integer bucketId, ResourceId destination, Integer totalNumBuckets) {
+      this(bucketId, 0, 1, destination, totalNumBuckets);
+    }
+
+    MergedBucket(
+        Integer bucketId,
+        Integer shardId,
+        Integer numShards,
+        ResourceId destination,
+        Integer totalNumBuckets) {
       this.destination = destination;
       this.bucketId = bucketId;
+      this.shardId = shardId;
+      this.numShards = numShards;
       this.totalNumBuckets = totalNumBuckets;
     }
 
@@ -293,12 +309,14 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
       MergedBucket that = (MergedBucket) o;
       return Objects.equals(destination, that.destination)
           && Objects.equals(bucketId, that.bucketId)
+          && shardId == that.shardId
+          && numShards == that.numShards
           && Objects.equals(totalNumBuckets, that.totalNumBuckets);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(destination, bucketId, totalNumBuckets);
+      return Objects.hash(destination, bucketId, shardId, numShards, totalNumBuckets);
     }
   }
 
@@ -453,56 +471,85 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
       int bucketId = e.bucketOffsetId;
       int effectiveParallelism = e.effectiveParallelism;
 
-      ResourceId dst =
-          fileAssignment.forBucket(BucketShardId.of(bucketId, 0), effectiveParallelism, 1);
-      OutputCollector<FinalValueT> outputCollector;
-      final Counter recordsWritten =
-          Metrics.counter(metricsPrefix, metricsPrefix + "-RecordsWritten");
-      try {
-        outputCollector = new OutputCollector<>(fileOperations.createWriter(dst), recordsWritten);
-      } catch (IOException err) {
-        throw new RuntimeException("Failed to create file writer for transformed output", err);
-      }
-
       // get any arbitrary metadata to be able to rehash keys into buckets
       BucketMetadata<?, ?, ?> someArbitraryBucketMetadata =
           sources.get(0).getSourceMetadata().mapping.values().stream().findAny().get().metadata;
-      final MultiSourceKeyGroupReader<FinalKeyT> iter =
-          new MultiSourceKeyGroupReader<FinalKeyT>(
-              sources,
-              keyFn,
-              coGbkResultSchema(),
-              someArbitraryBucketMetadata,
-              keyComparator,
-              metricsPrefix,
-              false,
-              bucketId,
-              effectiveParallelism,
-              context.getPipelineOptions());
-      while (true) {
-        try {
-          KV<FinalKeyT, CoGbkResult> mergedKeyGroup = iter.readNext();
-          if (mergedKeyGroup == null) break;
-          outputTransform(mergedKeyGroup, context, outputCollector, window);
 
-          // exhaust iterators if necessary before moving on to the next key group:
-          // for example, if not every element was needed in the transformFn
-          sources.forEach(
-              source -> {
-                final Iterable<?> maybeUnfinishedIt =
-                    mergedKeyGroup.getValue().getAll(source.getTupleTag());
-                if (SortedBucketSource.TraversableOnceIterable.class.isAssignableFrom(
-                    maybeUnfinishedIt.getClass())) {
-                  ((SortedBucketSource.TraversableOnceIterable<?>) maybeUnfinishedIt)
-                      .ensureExhausted();
-                }
-              });
-        } catch (Exception ex) {
-          throw new RuntimeException("Failed to write merged key group", ex);
+      // Check if any source needs directory batching
+      SortedBucketSource.BucketedInput<?> batchedSource =
+          sources.stream()
+              .filter(SortedBucketSource.BucketedInput::needsBatching)
+              .findFirst()
+              .orElse(null);
+
+      List<Map<TupleTag<?>, Set<ResourceId>>> batchFilters;
+      if (batchedSource != null) {
+        TupleTag<?> tag = batchedSource.getTupleTag();
+        batchFilters = new java.util.ArrayList<>();
+        for (Set<ResourceId> batch : batchedSource.getDirectoryBatches()) {
+          Map<TupleTag<?>, Set<ResourceId>> filter = new HashMap<>();
+          filter.put(tag, batch);
+          batchFilters.add(filter);
         }
+      } else {
+        batchFilters = Collections.singletonList(null);
       }
-      outputCollector.onComplete();
-      out.output(new MergedBucket(bucketId, dst, effectiveParallelism));
+
+      int numShards = batchFilters.size();
+      final Counter recordsWritten =
+          Metrics.counter(metricsPrefix, metricsPrefix + "-RecordsWritten");
+
+      for (int shardIdx = 0; shardIdx < numShards; shardIdx++) {
+        Map<TupleTag<?>, Set<ResourceId>> dirFilter = batchFilters.get(shardIdx);
+
+        ResourceId dst =
+            fileAssignment.forBucket(
+                BucketShardId.of(bucketId, shardIdx), effectiveParallelism, numShards);
+        OutputCollector<FinalValueT> outputCollector;
+        try {
+          outputCollector = new OutputCollector<>(fileOperations.createWriter(dst), recordsWritten);
+        } catch (IOException err) {
+          throw new RuntimeException("Failed to create file writer for transformed output", err);
+        }
+
+        final MultiSourceKeyGroupReader<FinalKeyT> iter =
+            new MultiSourceKeyGroupReader<FinalKeyT>(
+                sources,
+                keyFn,
+                coGbkResultSchema(),
+                someArbitraryBucketMetadata,
+                keyComparator,
+                metricsPrefix,
+                false,
+                bucketId,
+                effectiveParallelism,
+                context.getPipelineOptions(),
+                dirFilter);
+        while (true) {
+          try {
+            KV<FinalKeyT, CoGbkResult> mergedKeyGroup = iter.readNext();
+            if (mergedKeyGroup == null) break;
+            outputTransform(mergedKeyGroup, context, outputCollector, window);
+
+            // exhaust iterators if necessary before moving on to the next key group:
+            // for example, if not every element was needed in the transformFn
+            sources.forEach(
+                source -> {
+                  final Iterable<?> maybeUnfinishedIt =
+                      mergedKeyGroup.getValue().getAll(source.getTupleTag());
+                  if (SortedBucketSource.TraversableOnceIterable.class.isAssignableFrom(
+                      maybeUnfinishedIt.getClass())) {
+                    ((SortedBucketSource.TraversableOnceIterable<?>) maybeUnfinishedIt)
+                        .ensureExhausted();
+                  }
+                });
+          } catch (Exception ex) {
+            throw new RuntimeException("Failed to write merged key group", ex);
+          }
+        }
+        outputCollector.onComplete();
+        out.output(new MergedBucket(bucketId, shardIdx, numShards, dst, effectiveParallelism));
+      }
     }
   }
 

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
@@ -282,7 +282,17 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
     keyClass: Class[K],
     a: SortedBucketIO.Read[A],
     b: SortedBucketIO.Read[B],
-    targetParallelism: TargetParallelism = TargetParallelism.auto()
+    targetParallelism: TargetParallelism,
+    lazyKeyGroups: Boolean
+  ): SCollection[(K, (Iterable[A], Iterable[B]))] =
+    SMBMultiJoin(self).sortMergeCoGroup(keyClass, a, b, targetParallelism, lazyKeyGroups)
+
+  @experimental
+  def sortMergeCoGroup[K: Coder, A: Coder, B: Coder](
+    keyClass: Class[K],
+    a: SortedBucketIO.Read[A],
+    b: SortedBucketIO.Read[B],
+    targetParallelism: TargetParallelism
   ): SCollection[(K, (Iterable[A], Iterable[B]))] =
     SMBMultiJoin(self).sortMergeCoGroup(keyClass, a, b, targetParallelism)
 
@@ -357,6 +367,17 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
    *   the desired parallelism of the job. See
    *   [[org.apache.beam.sdk.extensions.smb.TargetParallelism]] for more information.
    */
+  @experimental
+  def sortMergeCoGroup[K: Coder, A: Coder, B: Coder, C: Coder](
+    keyClass: Class[K],
+    a: SortedBucketIO.Read[A],
+    b: SortedBucketIO.Read[B],
+    c: SortedBucketIO.Read[C],
+    targetParallelism: TargetParallelism,
+    lazyKeyGroups: Boolean
+  ): SCollection[(K, (Iterable[A], Iterable[B], Iterable[C]))] =
+    SMBMultiJoin(self).sortMergeCoGroup(keyClass, a, b, c, targetParallelism, lazyKeyGroups)
+
   @experimental
   def sortMergeCoGroup[K: Coder, A: Coder, B: Coder, C: Coder](
     keyClass: Class[K],

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/util/SMBMultiJoin.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/util/SMBMultiJoin.scala
@@ -29,7 +29,7 @@ import org.typelevel.scalaccompat.annotation.nowarn
 
 import scala.jdk.CollectionConverters._
 final class SMBMultiJoin(private val self: ScioContext) {
-	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], targetParallelism: TargetParallelism): SCollection[(KEY, (Iterable[A], Iterable[B]))] = self.requireNotClosed {
+	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], targetParallelism: TargetParallelism, lazyKeyGroups: Boolean): SCollection[(KEY, (Iterable[A], Iterable[B]))] = self.requireNotClosed {
 		val tfName = self.tfName
 		val keyed = if (self.isTest) {
 			testCoGroup[KEY](a, b)
@@ -38,6 +38,7 @@ final class SMBMultiJoin(private val self: ScioContext) {
 				.read(keyClass)
 				.of(a, b)
 				.withTargetParallelism(targetParallelism)
+				.withLazyKeyGroups(lazyKeyGroups)
 			self.wrap(self.pipeline.apply(s"SMB CoGroupByKey@$tfName", transform))
 		}
 		val tupleTagA = a.getTupleTag
@@ -56,11 +57,15 @@ final class SMBMultiJoin(private val self: ScioContext) {
 			}
 	}
 
-	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B]): SCollection[(KEY, (Iterable[A], Iterable[B]))] = {
-		sortMergeCoGroup(keyClass, a, b, TargetParallelism.auto())
+	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], targetParallelism: TargetParallelism): SCollection[(KEY, (Iterable[A], Iterable[B]))] = {
+		sortMergeCoGroup(keyClass, a, b, targetParallelism, false)
 	}
 
-	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder, C: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], c: SortedBucketIO.Read[C], targetParallelism: TargetParallelism): SCollection[(KEY, (Iterable[A], Iterable[B], Iterable[C]))] = self.requireNotClosed {
+	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B]): SCollection[(KEY, (Iterable[A], Iterable[B]))] = {
+		sortMergeCoGroup(keyClass, a, b, TargetParallelism.auto(), false)
+	}
+
+	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder, C: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], c: SortedBucketIO.Read[C], targetParallelism: TargetParallelism, lazyKeyGroups: Boolean): SCollection[(KEY, (Iterable[A], Iterable[B], Iterable[C]))] = self.requireNotClosed {
 		val tfName = self.tfName
 		val keyed = if (self.isTest) {
 			testCoGroup[KEY](a, b, c)
@@ -69,6 +74,7 @@ final class SMBMultiJoin(private val self: ScioContext) {
 				.read(keyClass)
 				.of(a, b, c)
 				.withTargetParallelism(targetParallelism)
+				.withLazyKeyGroups(lazyKeyGroups)
 			self.wrap(self.pipeline.apply(s"SMB CoGroupByKey@$tfName", transform))
 		}
 		val tupleTagA = a.getTupleTag
@@ -89,8 +95,12 @@ final class SMBMultiJoin(private val self: ScioContext) {
 			}
 	}
 
+	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder, C: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], c: SortedBucketIO.Read[C], targetParallelism: TargetParallelism): SCollection[(KEY, (Iterable[A], Iterable[B], Iterable[C]))] = {
+		sortMergeCoGroup(keyClass, a, b, c, targetParallelism, false)
+	}
+
 	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder, C: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], c: SortedBucketIO.Read[C]): SCollection[(KEY, (Iterable[A], Iterable[B], Iterable[C]))] = {
-		sortMergeCoGroup(keyClass, a, b, c, TargetParallelism.auto())
+		sortMergeCoGroup(keyClass, a, b, c, TargetParallelism.auto(), false)
 	}
 
 	def sortMergeCoGroup[KEY: Coder, A: Coder, B: Coder, C: Coder, D: Coder](keyClass: Class[KEY], a: SortedBucketIO.Read[A], b: SortedBucketIO.Read[B], c: SortedBucketIO.Read[C], d: SortedBucketIO.Read[D], targetParallelism: TargetParallelism): SCollection[(KEY, (Iterable[A], Iterable[B], Iterable[C], Iterable[D]))] = self.requireNotClosed {

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIO.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIO.scala
@@ -64,7 +64,8 @@ object ParquetTypeSortedBucketIO {
     filenameSuffix: String = DefaultSuffix,
     filterPredicate: FilterPredicate = null,
     predicate: Predicate[T] = null,
-    configuration: Configuration = new Configuration()
+    configuration: Configuration = new Configuration(),
+    maxPartitionsPerBatch: Int = 0
   ) extends SortedBucketIO.Read[T] {
     def from(inputDirectories: String*): Read[T] =
       this.copy(inputDirectories = inputDirectories)
@@ -81,6 +82,9 @@ object ParquetTypeSortedBucketIO {
     def withConfiguration(configuration: Configuration): Read[T] =
       this.copy(configuration = configuration)
 
+    def withMaxPartitionsPerBatch(max: Int): Read[T] =
+      this.copy(maxPartitionsPerBatch = max)
+
     def getInputDirectories: ImmutableList[String] =
       ImmutableList.copyOf(inputDirectories.asJava: java.lang.Iterable[String])
     def getFilenameSuffix: String = filenameSuffix
@@ -90,7 +94,7 @@ object ParquetTypeSortedBucketIO {
     override def toBucketedInput(
       keying: SortedBucketSource.Keying
     ): SortedBucketSource.BucketedInput[T] = {
-      BucketedInput.of(
+      val input = BucketedInput.of(
         keying,
         getTupleTag,
         inputDirectories.asJava,
@@ -98,6 +102,8 @@ object ParquetTypeSortedBucketIO {
         getFileOperations,
         predicate
       )
+      if (maxPartitionsPerBatch > 0) input.setMaxPartitionsPerBatch(maxPartitionsPerBatch)
+      input
     }
 
     def getFileOperations: FileOperations[T] =


### PR DESCRIPTION
Two features to address OOM in SMB operations with many input partitions ([example](https://ghe.spotify.net/key-metrics/key-metrics-pipelines/pull/1270)):

1. Lazy key groups for CoGroup (withLazyKeyGroups):
   - CoGroup path previously always eagerly materialized all records per key group into a List. This causes OOM when key groups are large (e.g., 26 months of daily data per user).
   - New withLazyKeyGroups(true) option on sortMergeCoGroup makes the CoGbkResult iterables lazy (TraversableOnceIterable), matching the Transform path behavior. Callers must only iterate once.

2. Directory batching for Transform (withMaxPartitionsPerBatch):
   - When a BucketedInput has many input directories (e.g., 780 daily partitions), all Parquet file readers are opened simultaneously, exhausting heap from reader buffers alone.
   - New withMaxPartitionsPerBatch(N) on Read splits directories into batches of N. Each batch is processed as a separate shard in the output, keeping data sorted within each shard for valid downstream SMB reads. Non-batched sources are fully read for each batch.